### PR TITLE
Add stateKey as required parameter, update tests, update docs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
     "globals": {
         "describe": true,
-        "it": true
+        "it": true,
+        "sinon": true
     },
     "parser": "babel-eslint",
     "ecmaFeatures": {
@@ -32,68 +33,89 @@
     "plugins": [
         "react"
     ],
-    "rules": {
-        "semi": 2
-    },
     "env": {
         "browser": true,
         "node": true,
-        "es6": true
+        "es6": true,
+        "mocha": true
     },
     "rules": {
-        "comma-dangle": 1,
-        "no-cond-assign": [1, "except-parens"],
-        "no-console": 0,
-        "no-constant-condition": 1,
-        "no-control-regex": 1,
-        "no-debugger": 1,
-        "no-dupe-args": 1,
-        "no-dupe-keys": 1,
-        "no-duplicate-case": 0,
-        "no-empty-character-class": 1,
-        "no-empty": 1,
-        "no-ex-assign": 1,
-        "no-extra-boolean-cast": 1,
+        "comma-dangle": 2,
+        "no-cond-assign": [
+            1,
+            "except-parens"
+        ],
+        "no-console": 1,
+        "no-constant-condition": 2,
+        "no-control-regex": 2,
+        "no-debugger": 2,
+        "no-dupe-args": 2,
+        "no-dupe-keys": 2,
+        "no-duplicate-case": 2,
+        "no-empty-character-class": 2,
+        "no-empty": 2,
+        "no-ex-assign": 2,
+        "no-extra-boolean-cast": 2,
         "no-extra-parens": 0,
-        "no-extra-semi": 1,
-        "no-func-assign": 1,
-        "no-inner-declarations": [1, "functions"],
-        "no-invalid-regexp": 1,
-        "no-irregular-whitespace": 1,
-        "no-negated-in-lhs": 1,
-        "no-obj-calls": 1,
-        "no-regex-spaces": 1,
-        "no-reserved-keys": 0,
-        "no-sparse-arrays": 1,
-        "no-unexpected-multiline": 1,
-        "no-unreachable": 1,
-        "use-isnan": 1,
-        "valid-jsdoc": 1,
+        "no-extra-semi": 2,
+        "no-func-assign": 2,
+        "no-inner-declarations": [
+            2,
+            "functions"
+        ],
+        "no-invalid-regexp": 2,
+        "no-irregular-whitespace": 2,
+        "no-negated-in-lhs": 2,
+        "no-obj-calls": 2,
+        "no-regex-spaces": 2,
+        "no-sparse-arrays": 2,
+        "no-unexpected-multiline": 2,
+        "no-unreachable": 2,
+        "use-isnan": 2,
+        "valid-jsdoc": [
+            2,
+            {
+                "requireReturnDescription": false,
+                "requireParamDescription": false,
+                "requireReturn": false
+            }
+        ],
+        "require-jsdoc": 0,
         "valid-typeof": 1,
-
         "accessor-pairs": 0,
         "block-scoped-var": 0,
         "complexity": 0,
-        "consistent-return": 1,
-        "curly": [1, "all"],
+        "consistent-return": 0,
+        "curly": [
+            1,
+            "all"
+        ],
         "default-case": 0,
-        "dot-notation": [1, { "allowKeywords": true, "allowPattern": "" }],
-        "dot-location": [1, "property"],
+        "dot-notation": [
+            1,
+            {
+                "allowKeywords": true,
+                "allowPattern": ""
+            }
+        ],
+        "dot-location": [
+            1,
+            "property"
+        ],
         "eqeqeq": 1,
         "guard-for-in": 0,
         "no-alert": 1,
         "no-caller": 1,
         "no-div-regex": 1,
-        "no-else-return": 0,
-        "no-empty-label": 1,
+        "no-else-return": 1,
+        "no-labels": 1,
         "no-eq-null": 0,
-        "no-eval": 1,
+        "no-eval": 2,
         "no-extra-bind": 1,
         "no-fallthrough": 0,
         "no-floating-decimal": 1,
         "no-implied-eval": 1,
         "no-iterator": 1,
-        "no-labels": 1,
         "no-lone-blocks": 1,
         "no-loop-func": 1,
         "no-multi-spaces": 1,
@@ -106,7 +128,7 @@
         "no-octal": 1,
         "no-param-reassign": 0,
         "no-process-env": 0,
-        "no-proto": 1,
+        "no-proto": 2,
         "no-redeclare": 1,
         "no-return-assign": 1,
         "no-script-url": 1,
@@ -114,82 +136,183 @@
         "no-sequences": 1,
         "no-throw-literal": 1,
         "no-unused-expressions": 0,
-        "no-void": 0,
-        "no-warning-comments": [1, { "terms": ["todo", "tofix"], "location": "start" }],
+        "no-void": 2,
+        "no-warning-comments": [
+            1,
+            {
+                "terms": [
+                    "todo",
+                    "tofix"
+                ],
+                "location": "start"
+            }
+        ],
         "no-with": 1,
         "radix": 1,
         "vars-on-top": 1,
-        "wrap-iife": [1, "inside"],
-        "yoda": [1, "never"],
-
-        "strict": [1, "never"],
-
+        "wrap-iife": [
+            1,
+            "inside"
+        ],
+        "yoda": [
+            1,
+            "never"
+        ],
+        "strict": [
+            2,
+            "never"
+        ],
         "no-catch-shadow": 0,
         "no-delete-var": 1,
         "no-label-var": 1,
         "no-shadow-restricted-names": 1,
         "no-shadow": 1,
-        "no-undef-init": 1,
-        "no-undef": 1,
+        "no-undef-init": 2,
+        "no-undef": 2,
         "no-undefined": 0,
-        "no-unused-vars": [1, { "vars": "local", "args": "after-used" }],
+        "no-unused-vars": [
+            1,
+            {
+                "vars": "local",
+                "args": "after-used"
+            }
+        ],
         "no-use-before-define": 0,
-
         "handle-callback-err": 1,
         "no-mixed-requires": 1,
         "no-new-require": 1,
         "no-path-concat": 1,
         "no-process-exit": 1,
-        "no-restricted-modules": [1, ""], 
+        "no-restricted-modules": [
+            1,
+            ""
+        ],
         "no-sync": 1,
-
-        "array-bracket-spacing": [1, "never"],
-        "brace-style": [1, "stroustrup", { "allowSingleLine": true }],
-        "camelcase": [1, { "properties": "always" }],
-        "comma-spacing": [1, { "before": false, "after": true }],
-        "comma-style": [1, "last"],
+        "array-bracket-spacing": [
+            1,
+            "never"
+        ],
+        "brace-style": [
+            1,
+            "stroustrup",
+            {
+                "allowSingleLine": true
+            }
+        ],
+        "camelcase": [
+            1,
+            {
+                "properties": "always"
+            }
+        ],
+        "comma-spacing": [
+            1,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
+        "comma-style": [
+            1,
+            "last"
+        ],
         "computed-property-spacing": 0,
         "consistent-this": 0,
         "func-names": 1,
         "func-style": 0,
-        "indent": [1, 4],
-        "key-spacing": [1, { "beforeColon": false, "afterColon": true }],
-        "linebreak-style": 0,
-        "max-nested-callbacks": [0, 3],
-        "new-cap": 0, 
+        "indent": [
+            2,
+            4
+        ],
+        "key-spacing": [
+            2,
+            {
+                "beforeColon": false,
+                "afterColon": true
+            }
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "max-nested-callbacks": [
+            0,
+            3
+        ],
+        "new-cap": 0,
         "new-parens": 1,
         "newline-after-var": 0,
-        "no-array-constructor": 1,
-        "no-continue": 1,
+        "no-array-constructor": 2,
+        "no-continue": 2,
         "no-inline-comments": 0,
         "no-lonely-if": 1,
-        "no-mixed-spaces-and-tabs": 1,
-        "no-multiple-empty-lines": [1, { "max": 1 }],
+        "no-mixed-spaces-and-tabs": 2,
+        "no-multiple-empty-lines": [
+            2,
+            {
+                "max": 1
+            }
+        ],
         "no-nested-ternary": 0,
-        "no-new-object": 1,
-        "no-spaced-func": 1,
+        "no-new-object": 2,
+        "no-spaced-func": 2,
         "no-ternary": 0,
-        "no-trailing-spaces": 1,
+        "no-trailing-spaces": 2,
         "no-underscore-dangle": 0,
         "no-unneeded-ternary": 1,
         "object-curly-spacing": 0,
-        "one-var": [1, "never"],
-        "padded-blocks": [0, "never"],
-        "quote-props": [0, "as-needed"],
-        "quotes": [1, "single"],
-        "semi-spacing": [1, { "before": false, "after": true }],
-        "semi": [1, "always"],
+        "one-var": [
+            1,
+            "never"
+        ],
+        "padded-blocks": [
+            0,
+            "never"
+        ],
+        "quote-props": [
+            2,
+            "as-needed",
+            {
+                "keywords": true
+            }
+        ],
+        "quotes": [
+            2,
+            "single"
+        ],
+        "semi-spacing": [
+            2,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
+        "semi": [
+            2,
+            "always"
+        ],
         "sort-vars": 0,
         "space-after-keywords": 0,
-        "space-before-blocks": [1, "always"],
-        "space-before-function-paren": [1, "never"],
-        "space-in-parens": [1, "never"],
+        "space-before-blocks": [
+            1,
+            "always"
+        ],
+        "space-before-function-paren": [
+            2,
+            "never"
+        ],
+        "space-in-parens": [
+            1,
+            "never"
+        ],
         "space-infix-ops": 1,
-        "space-return-throw-case": 1,
+        "keyword-spacing": 2,
         "space-unary-ops": 0,
-        "spaced-comment": [1, "always"],
-        "wrap-regex": 1,
-
+        "spaced-comment": [
+            1,
+            "always"
+        ],
+        "wrap-regex": 0,
         "react/display-name": 0,
         "react/forbid-prop-types": 0,
         "react/jsx-boolean-value": 1,
@@ -199,14 +322,14 @@
         "react/jsx-indent-props": 1,
         "react/jsx-indent": 1,
         "react/jsx-key": 1,
-        "react/jsx-max-props-per-line": 0,
-        "react/jsx-no-bind": 0,
+        "react/jsx-max-props-per-line": 1,
+        "react/jsx-no-bind": 1,
         "react/jsx-no-duplicate-props": 1,
         "react/jsx-no-literals": 1,
         "react/jsx-no-undef": 1,
         "react/jsx-pascal-case": 1,
         "jsx-quotes": 1,
-        "react/jsx-sort-prop-types": 1,
+        "react/sort-prop-types": 2,
         "react/jsx-sort-props": 1,
         "react/jsx-uses-react": 1,
         "react/jsx-uses-vars": 1,
@@ -218,25 +341,64 @@
         "react/no-is-mounted": 1,
         "react/no-multi-comp": 1,
         "react/no-set-state": 1,
-        "react/no-string-refs": 0,
+        "react/no-string-refs": 1,
         "react/no-unknown-property": 1,
-        "react/prefer-es6-class": 1,
-        "react/prop-types": 1,
+        "react/prefer-es6-class": 2,
+        "react/prefer-stateless-function": 2,
+        "react/prop-types": 2,
         "react/react-in-jsx-scope": 1,
         "react/require-extension": 1,
         "react/self-closing-comp": 1,
-        "react/sort-comp": 1,
+        "react/sort-comp": [
+            2,
+            {
+                "order": [
+                    "render",
+                    "lifecycle",
+                    "static-methods",
+                    "everything-else"
+                ],
+                "groups": {
+                    "lifecycle": [
+                        "componentWillMount",
+                        "componentDidMount",
+                        "componentWillReceiveProps",
+                        "shouldComponentUpdate",
+                        "componentWillUpdate",
+                        "componentDidUpdate",
+                        "componentWillUnmount",
+                        "getChildContext",
+                        "contextTypes",
+                        "childContextTypes",
+                        "mixins",
+                        "state",
+                        "statics",
+                        "displayName",
+                        "propTypes",
+                        "defaultProps",
+                        "constructor",
+                        "getDefaultProps",
+                        "getInitialState"
+                    ]
+                }
+            }
+        ],
         "react/wrap-multilines": 1,
-        
         "constructor-super": 1,
-        "generator-star-spacing": 0, 
+        "generator-star-spacing": 0,
         "no-this-before-super": 1,
-        "no-var": 1,
+        "no-var": 2,
         "object-shorthand": 0,
-        "prefer-const": 1,
-
-        "max-depth": [0, 3],
-        "max-len": [1, 121, 2],
+        "prefer-const": 2,
+        "max-depth": [
+            0,
+            3
+        ],
+        "max-len": [
+            2,
+            80,
+            4
+        ],
         "max-params": 0,
         "max-statements": 0,
         "no-bitwise": 1,

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,3 @@ before_script: npm cache clear
 node_js:
   - "4.1"
   - "4.0"
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"

--- a/README.MD
+++ b/README.MD
@@ -61,6 +61,7 @@ If you're using the fonts that come bundles with the grid, you will also need an
 
 	const gridData = {
 		store: Store,
+		stateKey: 'unique-grid-id',
 		...data
 	};
 
@@ -103,6 +104,10 @@ You can import a reducer like so:
 	    dataSource,
 	    yourCustomReducer
 	};
+
+## What's a `stateKey`?
+
+A `stateKey` is a unique id associated with each grid instantiation, and is a required parameter. Because all grid data is stored in a `reducer`, we need a unique key to access each grid's subsection of data in these objects. If a grid is instantiated without a `stateKey`, it will will throw a user error in the console. If a duplicate `stateKey` is passed to grid it will throw a user error in the console. In short, please provide a unique `stateKey` to each grid you create.
 
 ## Data
 

--- a/demo/demoData.js
+++ b/demo/demoData.js
@@ -5,6 +5,8 @@ import { Actions } from './../src/actions';
 
 export const pageSize = 20;
 
+export const stateKey = 'grid-stateKey';
+
 export const height = '400px';
 
 export const events = {
@@ -130,11 +132,17 @@ export const plugins = {
     }
 };
 
-export const editorFunc = (value, editorState, rowId, columns, idx, reactEvent) => {
+export const editorFunc = (
+    value, row, column, columns, columnIndex, stateKey, reactEvent
+) => {
     store.dispatch(
-        Actions.EditorActions.updateCellValue(
-            reactEvent.target.value, columns[idx].name
-        )
+        Actions.EditorActions.updateCellValue({
+            value: reactEvent.target.value,
+            name: column.dataIndex,
+            column,
+            columns,
+            stateKey
+        })
     );
 };
 
@@ -153,10 +161,18 @@ export const columns = [
         sortable: true,
         width: '20%',
         className: 'additional-class',
-        editor: (value, editorState, rowId, cols, index) => {
+        editor: (
+            /* eslint-disable  react/prop-types */
+            { column, columnIndex, row, stateKey, store, value }
+            /* eslint-enable  react/prop-types */
+        ) => {
             return (
                 <input
-                    onChange= { editorFunc.bind(null, value, editorState, rowId, cols, index) }
+                    onChange= {
+                        editorFunc.bind(
+                            null, value, row, column, columns, columnIndex, stateKey
+                        )
+                    }
                     type="tel"
                     value={ value }
                 />

--- a/demo/provider.jsx
+++ b/demo/provider.jsx
@@ -9,7 +9,8 @@ import {
     plugins,
     events,
     dataSource,
-    height
+    height,
+    stateKey
 } from '../demo/demoData';
 
 const gridData = {
@@ -20,6 +21,7 @@ const gridData = {
     events,
     dataSource,
     height,
+    stateKey,
     store: Store
 };
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "karma-eslint": "^2.0.1",
     "karma-expect": "^1.1.1",
     "karma-jasmine": "^0.3.6",
+    "karma-jsdom-launcher": "^3.0.0",
     "karma-mocha": "^0.2.1",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sinon-chai": "^1.2.0",

--- a/src/actions/GridActions.js
+++ b/src/actions/GridActions.js
@@ -7,8 +7,6 @@ import {
     SET_SORT_DIRECTION
 } from '../constants/ActionTypes';
 
-import { SORT_DIRECTIONS } from '../constants/GridConstants';
-
 import { setLoaderState } from '../actions/plugins/loader/LoaderActions';
 
 import { dismissEditor } from '../actions/plugins/editor/EditorActions';
@@ -17,52 +15,68 @@ import { keyGenerator } from '../util/keyGenerator';
 
 import Request from '../components/plugins/ajax/Request';
 
-export function getAsyncData(datasource) {
+export function getAsyncData({ stateKey, dataSource }) {
 
     return (dispatch) => {
 
-        dispatch(dismissEditor());
+        dispatch(dismissEditor({ stateKey }));
 
-        dispatch(setLoaderState(true));
+        dispatch(
+            setLoaderState({state: true, stateKey })
+        );
 
-        if (typeof datasource === 'function') {
+        if (typeof dataSource === 'function') {
 
-            datasource().then((response) => {
+            dataSource().then((response) => {
 
                 if (response && response.data) {
 
-                    dispatch({
+                    dispatch(
+                        setLoaderState({ state: false, stateKey })
+                    );
+
+                    return dispatch({
                         type: SET_DATA,
                         data: response.data,
                         total: response.total,
                         currentRecords: response.data,
-                        success: true
+                        success: true,
+                        stateKey
                     });
 
                 }
 
-                else {
-
-                    if (response && !response.data) {
-                        console.warn('A response was recieved but no data entry was found');
-                        console.warn('Please see https://github.com/bencripps/react-redux-grid for documentation');
-                    }
-
-                    dispatch({
-                        type: ERROR_OCCURRED,
-                        error: 'Unable to Retrieve Grid Data',
-                        errorOccurred: true
-                    });
+                if (response && !response.data) {
+                    /* eslint-disable no-console */
+                    console.warn(
+                        `A response was recieved
+                         but no data entry was found`
+                    );
+                    console.warn(
+                        `Please see 
+                         https://github.com/bencripps/react-redux-grid
+                         for documentation`
+                    );
+                    /* eslint-enable no-console */
                 }
 
-                dispatch(setLoaderState(false));
+                dispatch({
+                    type: ERROR_OCCURRED,
+                    error: 'Unable to Retrieve Grid Data',
+                    errorOccurred: true,
+                    stateKey
+                });
+
+                dispatch(
+                    setLoaderState({ state: false, stateKey })
+                );
             });
         }
 
-        else if (typeof datasource === 'string') {
+        else if (typeof dataSource === 'string') {
 
             return Request.api({
-                route: datasource,
+                route: dataSource,
                 method: 'GET'
             }).then((response) => {
 
@@ -73,7 +87,8 @@ export function getAsyncData(datasource) {
                         data: response.data,
                         total: response.total,
                         currentRecords: response.data,
-                        success: true
+                        success: true,
+                        stateKey
                     });
 
                 }
@@ -82,31 +97,33 @@ export function getAsyncData(datasource) {
                     dispatch({
                         type: ERROR_OCCURRED,
                         error: 'Unable to Retrieve Grid Data',
-                        errorOccurred: true
+                        errorOccurred: true,
+                        stateKey
                     });
                 }
 
-                dispatch(setLoaderState(false));
+                dispatch(
+                    setLoaderState({state: false, stateKey })
+                );
             });
 
         }
 
-
     };
 }
 
-export function setColumns(cols) {
+export function setColumns({ columns, stateKey }) {
 
-    let columns = cols;
+    let cols = columns;
 
-    if (!columns[0].id) {
-        columns = cols.map((col) => {
+    if (!cols[0].id) {
+        cols = columns.map((col) => {
             col.id = keyGenerator(col.name, 'grid-column');
             return col;
         });
     }
 
-    return { type: SET_COLUMNS, columns };
+    return { type: SET_COLUMNS, columns: cols, stateKey };
 }
 
 export function setSortDirection(cols, id, sortDirection) {
@@ -131,17 +148,22 @@ export function setSortDirection(cols, id, sortDirection) {
     return { type: SET_SORT_DIRECTION, columns };
 }
 
-export function doLocalSort(data) {
-    return { type: SORT_DATA, data };
+export function doLocalSort({ data, stateKey }) {
+    return { type: SORT_DATA, data, stateKey };
 }
 
-export function doRemoteSort(datasource, pageIndex, pageSize, sortParams) {
+export function doRemoteSort(
+    { dataSource, pageIndex, pageSize, sortParams, stateKey }
+) {
+
     return (dispatch) => {
 
-        dispatch(setLoaderState(true));
+        dispatch(
+            setLoaderState({state: true, stateKey })
+        );
 
-        if (typeof datasource === 'function') {
-            return datasource({}, {}, sortParams).then((response) => {
+        if (typeof dataSource === 'function') {
+            return dataSource({}, {}, sortParams).then((response) => {
 
                 if (response && response.data) {
 
@@ -150,7 +172,8 @@ export function doRemoteSort(datasource, pageIndex, pageSize, sortParams) {
                         data: response.data,
                         total: response.total,
                         currentRecords: response.items,
-                        success: true
+                        success: true,
+                        stateKey
                     });
 
                 }
@@ -158,64 +181,76 @@ export function doRemoteSort(datasource, pageIndex, pageSize, sortParams) {
                 else {
 
                     if (response && !response.data) {
-                        console.warn('A response was recieved but no data entry was found');
-                        console.warn('Please see https://github.com/bencripps/react-redux-grid for documentation');
+                        /* eslint-disable no-console */
+                        console.warn(
+                            `A response was recieved but no data
+                             entry was found`
+                        );
+                        console.warn(
+                            `Please see 
+                             https://github.com/bencripps/react-redux-grid 
+                             for documentation`
+                        );
+                        /* eslint-enable no-console */
                     }
 
                     dispatch({
                         type: ERROR_OCCURRED,
                         error: 'Unable to Retrieve Grid Data',
-                        errorOccurred: true
+                        errorOccurred: true,
+                        stateKey
                     });
                 }
 
-                dispatch(setLoaderState(false));
+                dispatch(
+                    setLoaderState({state: false, stateKey })
+                );
             });
 
         }
 
-        else {
-            return Request.api({
-                route: datasource,
-                method: 'POST',
-                data: {
-                    pageIndex: pageIndex,
-                    pageSize: pageSize,
-                    sort: sortParams.sort
-                }
-            }).then((response) => {
+        return Request.api({
+            route: dataSource,
+            method: 'POST',
+            data: {
+                pageIndex: pageIndex,
+                pageSize: pageSize,
+                sort: sortParams.sort
+            }
+        }).then((response) => {
 
-                if (response && response.data) {
+            if (response && response.data) {
 
-                    dispatch({
-                        type: SET_DATA,
-                        data: response.data,
-                        total: response.total,
-                        currentRecords: response.data,
-                        success: true
-                    });
+                dispatch({
+                    type: SET_DATA,
+                    data: response.data,
+                    total: response.total,
+                    currentRecords: response.data,
+                    success: true
+                });
 
-                }
+            }
 
-                else {
-                    dispatch({
-                        type: ERROR_OCCURRED,
-                        error: 'Unable to Retrieve Grid Data',
-                        errorOccurred: true
-                    });
-                }
+            else {
+                dispatch({
+                    type: ERROR_OCCURRED,
+                    error: 'Unable to Retrieve Grid Data',
+                    errorOccurred: true
+                });
+            }
 
-                dispatch(setLoaderState(false));
-            });
-        }
+            dispatch(
+                setLoaderState({state: false, stateKey })
+            );
+        });
 
     };
 }
 
-export function setColumnVisibility(columnsArr, column, isHidden) {
+export function setColumnVisibility({ columns, column, isHidden, stateKey }) {
     const hidden = !isHidden;
 
-    const columns = columnsArr.map((col) => {
+    const columnsArr = columns.map((col) => {
         if (col.name === column.name) {
             col.hidden = hidden;
         }
@@ -223,10 +258,10 @@ export function setColumnVisibility(columnsArr, column, isHidden) {
         return col;
     });
 
-    return { type: SET_COLUMNS, columns };
+    return { type: SET_COLUMNS, columns: columnsArr, stateKey };
 }
 
-export function resizeColumns(width, id, nextColumn, cols) {
+export function resizeColumns(width, id, nextColumn, cols, stateKey) {
 
     const columns = cols.map((col) => {
 
@@ -244,11 +279,12 @@ export function resizeColumns(width, id, nextColumn, cols) {
 
     return {
         type: RESIZE_COLUMNS,
+        stateKey,
         columns
     };
 
 }
 
-export function setData(data) {
-    return { type: SET_DATA, data };
+export function setData({ data, stateKey }) {
+    return { type: SET_DATA, data, stateKey };
 }

--- a/src/actions/core/ColumnManager.js
+++ b/src/actions/core/ColumnManager.js
@@ -2,7 +2,9 @@ import {
     SET_COLUMNS
 } from '../../constants/ActionTypes';
 
-export function reorderColumn(draggedIndex, droppedIndex, columns) {
+export const reorderColumn = ({
+    draggedIndex, droppedIndex, columns, stateKey
+}) => {
 
     const reorder = (cols, to, from) => {
         cols.splice(to, 0, cols.splice(from, 1)[0]);
@@ -13,6 +15,7 @@ export function reorderColumn(draggedIndex, droppedIndex, columns) {
 
     return {
         type: SET_COLUMNS,
-        columns: reorderedColumns
+        columns: reorderedColumns,
+        stateKey
     };
-}
+};

--- a/src/actions/plugins/actioncolumn/MenuActions.js
+++ b/src/actions/plugins/actioncolumn/MenuActions.js
@@ -3,10 +3,10 @@ import {
     HIDE_MENU
 } from '../../../constants/ActionTypes';
 
-export function showMenu(id) {
-    return { type: SHOW_MENU, id };
+export function showMenu({ id, stateKey }) {
+    return { type: SHOW_MENU, id, stateKey };
 }
 
-export function hideMenu(id) {
-    return { type: HIDE_MENU, id };
+export function hideMenu({ id, stateKey }) {
+    return { type: HIDE_MENU, id, stateKey };
 }

--- a/src/actions/plugins/bulkactions/ToolbarActions.js
+++ b/src/actions/plugins/bulkactions/ToolbarActions.js
@@ -2,6 +2,6 @@ import {
     REMOVE_TOOLBAR
 } from '../../../constants/ActionTypes';
 
-export function removeToolbar(value) {
-    return { type: REMOVE_TOOLBAR, value };
+export function removeToolbar({ state, stateKey }) {
+    return { type: REMOVE_TOOLBAR, value: state, stateKey };
 }

--- a/src/actions/plugins/editor/EditorActions.js
+++ b/src/actions/plugins/editor/EditorActions.js
@@ -11,35 +11,53 @@ import {
 
 import { keyGenerator } from '../../../util/keyGenerator';
 
-export function editRow(rowId, top, rowData, rowIndex, columns, isCreate) {
-    return { type: EDIT_ROW, rowId, top, values: rowData, rowIndex, columns, isCreate };
+export function editRow({
+    rowId, top, rowData, rowIndex, columns, isCreate, stateKey
+}) {
+    return {
+        type: EDIT_ROW,
+        rowId,
+        top,
+        values: rowData,
+        rowIndex,
+        columns,
+        isCreate,
+        stateKey
+    };
 }
 
-export function dismissEditor() {
-    return { type: DISMISS_EDITOR };
+export function dismissEditor({ stateKey }) {
+    return { type: DISMISS_EDITOR, stateKey };
 }
 
-export function updateCellValue(value, name, column, columns) {
-    return { type: ROW_VALUE_CHANGE, value, columnName: name, column, columns };
+export function updateCellValue({ value, name, column, columns, stateKey }) {
+    return {
+        type: ROW_VALUE_CHANGE,
+        value,
+        columnName: name,
+        column,
+        columns,
+        stateKey
+    };
 }
 
-export function saveRow(values, rowIndex) {
-    return { type: SAVE_ROW, values, rowIndex };
+export function saveRow({ values, rowIndex, stateKey }) {
+    return { type: SAVE_ROW, values, rowIndex, stateKey };
 }
 
-export function cancelRow() {
-    return { type: CANCEL_ROW };
+export function cancelRow({ stateKey }) {
+    return { type: CANCEL_ROW, stateKey };
 }
 
-export function removeRow(rowIndex) {
-    return { type: REMOVE_ROW, rowIndex };
+export function removeRow({ rowIndex, stateKey }) {
+    return { type: REMOVE_ROW, rowIndex, stateKey };
 }
 
-export function setEditorValidation(validationState) {
-    return { type: EDITOR_VALIDATION, validationState };
+export function setEditorValidation({ validationState, stateKey }) {
+    return { type: EDITOR_VALIDATION, validationState, stateKey };
 }
 
-export function addNewRow(columns, data) {
+export function addNewRow({ columns, data, stateKey }) {
 
     return (dispatch) => {
         const rowId = keyGenerator('row', 0);
@@ -48,10 +66,18 @@ export function addNewRow(columns, data) {
         const rowIndex = 0;
         const isCreate = true;
 
-        dispatch({ type: ADD_NEW_ROW });
+        dispatch({ type: ADD_NEW_ROW, stateKey });
 
         dispatch(
-            editRow(rowId, top, rowData, rowIndex, columns, isCreate)
+            editRow({
+                rowId,
+                top,
+                rowData,
+                rowIndex,
+                columns,
+                isCreate,
+                stateKey
+            })
         );
     };
 }

--- a/src/actions/plugins/filter/FilterActions.js
+++ b/src/actions/plugins/filter/FilterActions.js
@@ -15,7 +15,7 @@ import { setLoaderState } from '../../../actions/plugins/loader/LoaderActions';
 
 import { getAsyncData } from '../../../actions/GridActions';
 
-export function setFilter(value) {
+export function setFilter({ value, stateKey }) {
 
     const metaData = {
         filterMenuShown: false,
@@ -24,27 +24,29 @@ export function setFilter(value) {
     };
 
     if (value || value.length > 0) {
-        return { type: SET_FILTER_VALUE, value };
+        return { type: SET_FILTER_VALUE, value, stateKey };
     }
 
-    else {
-        return { type: SHOW_FILTER_MENU, metaData };
-    }
+    return { type: SHOW_FILTER_MENU, metaData, stateKey };
 
 }
 
-export function doLocalFilter(data) {
-    return { type: FILTER_DATA, data };
+export function doLocalFilter({ data, stateKey }) {
+    return { type: FILTER_DATA, data, stateKey };
 }
 
-export function doRemoteFilter(filterParams, pageIndex, pageSize, datasource) {
+export function doRemoteFilter(
+    { filterParams, pageIndex, pageSize, dataSource, stateKey }
+) {
 
     return (dispatch) => {
 
-        dispatch(setLoaderState(true));
+        dispatch(
+            setLoaderState({ state: true, stateKey })
+        );
 
         return Request.api({
-            route: datasource,
+            route: dataSource,
             method: 'POST',
             data: {
                 pageIndex: pageIndex,
@@ -73,25 +75,28 @@ export function doRemoteFilter(filterParams, pageIndex, pageSize, datasource) {
                 });
             }
 
-            dispatch(setLoaderState(false));
+            dispatch(
+                setLoaderState({ state: false, stateKey })
+            );
+
         });
 
     };
 }
 
-export function setFilterMenuValues(filter) {
-    return { type: SET_FILTER_MENU_VALUES, filter };
+export function setFilterMenuValues({ filter, stateKey }) {
+    return { type: SET_FILTER_MENU_VALUES, filter, stateKey };
 }
 
-export function clearFilterRemote(dataSource) {
-    return getAsyncData(dataSource);
+export function clearFilterRemote({ dataSource, stateKey }) {
+    return getAsyncData({ dataSource, stateKey });
 }
 
-export function clearFilterLocal() {
-    return { type: CLEAR_FILTER_LOCAL };
+export function clearFilterLocal({ stateKey }) {
+    return { type: CLEAR_FILTER_LOCAL, stateKey };
 }
 
-export function showFilterMenu(value, removeFilters) {
+export function showFilterMenu({ value, removeFilters, stateKey }) {
     const isShown = !value;
 
     const metaData = {
@@ -102,5 +107,5 @@ export function showFilterMenu(value, removeFilters) {
         metaData.filterMenuValues = {};
     }
 
-    return { type: SHOW_FILTER_MENU, metaData };
+    return { type: SHOW_FILTER_MENU, metaData, stateKey };
 }

--- a/src/actions/plugins/loader/LoaderActions.js
+++ b/src/actions/plugins/loader/LoaderActions.js
@@ -2,6 +2,6 @@ import {
     SET_LOADING_STATE
 } from '../../../constants/ActionTypes';
 
-export function setLoaderState(state) {
-    return { type: SET_LOADING_STATE, state };
+export function setLoaderState({ state, stateKey }) {
+    return { type: SET_LOADING_STATE, state, stateKey };
 }

--- a/src/actions/plugins/pager/PagerActions.js
+++ b/src/actions/plugins/pager/PagerActions.js
@@ -11,24 +11,30 @@ import { dismissEditor } from '../../../actions/plugins/editor/EditorActions';
 
 import Request from '../../../components/plugins/ajax/Request';
 
-export function setPage(index, type, BUTTON_TYPES) {
+export function setPage({ index, type, BUTTON_TYPES }) {
 
     const pageIndex = type === BUTTON_TYPES.NEXT ? index + 1 : index - 1;
 
     return { type: PAGE_LOCAL, pageIndex };
 }
 
-export function setPageIndexAsync(pageIndex, pageSize, datasource, filterFields, sort, afterAsyncFunc) {
+export function setPageIndexAsync({
+    pageIndex, pageSize, dataSource, filterFields, sort, stateKey, afterAsyncFunc
+}) {
 
-    if (typeof datasource === 'function') {
+    if (typeof dataSource === 'function') {
 
         return (dispatch) => {
 
-            dispatch(dismissEditor());
+            dispatch(dismissEditor({ stateKey }));
 
-            dispatch(setLoaderState(true));
+            dispatch(
+                setLoaderState({ state: true, stateKey })
+            );
 
-            datasource({pageIndex, pageSize}, filterFields, sort).then((response) => {
+            dataSource(
+                {pageIndex, pageSize}, filterFields, sort
+            ).then((response) => {
 
                 if (response && response.data) {
 
@@ -37,10 +43,12 @@ export function setPageIndexAsync(pageIndex, pageSize, datasource, filterFields,
                         data: response.data,
                         total: response.total,
                         currentRecords: response.items,
-                        success: true
+                        success: true,
+                        stateKey
                     });
 
-                    if (afterAsyncFunc && typeof afterAsyncFunc === 'function') {
+                    if (afterAsyncFunc
+                        && typeof afterAsyncFunc === 'function') {
                         afterAsyncFunc();
                     }
                 }
@@ -55,26 +63,33 @@ export function setPageIndexAsync(pageIndex, pageSize, datasource, filterFields,
                     dispatch({
                         type: ERROR_OCCURRED,
                         error: 'Unable to Retrieve Grid Data',
-                        errorOccurred: true
+                        errorOccurred: true,
+                        stateKey
                     });
                 }
 
-                dispatch(setLoaderState(false));
+                dispatch(
+                    setLoaderState({ state: false, stateKey })
+                );
             });
         };
     }
 }
 
-export function setPageAsync(index, pageSize, type, BUTTON_TYPES, datasource) {
+export function setPageAsync({
+    index, pageSize, type, BUTTON_TYPES, dataSource, stateKey
+}) {
 
     const pageIndex = type === BUTTON_TYPES.NEXT ? index + 1 : index - 1;
 
     return (dispatch) => {
 
-        dispatch(setLoaderState(true));
+        dispatch(
+            setLoaderState({ state: true, stateKey })
+        );
 
         return Request.api({
-            route: datasource,
+            route: dataSource,
             method: 'POST',
             data: {
                 pageIndex: pageIndex,
@@ -86,7 +101,8 @@ export function setPageAsync(index, pageSize, type, BUTTON_TYPES, datasource) {
 
                 dispatch({
                     type: PAGE_REMOTE,
-                    pageIndex: pageIndex
+                    pageIndex: pageIndex,
+                    stateKey
                 });
 
                 dispatch({
@@ -94,17 +110,21 @@ export function setPageAsync(index, pageSize, type, BUTTON_TYPES, datasource) {
                     data: response.data,
                     total: response.total,
                     currentRecords: response.data,
-                    success: true
+                    success: true,
+                    stateKey
                 });
 
-                dispatch(setLoaderState(false));
+                dispatch(
+                    setLoaderState({ state: false, stateKey })
+                );
             }
 
             else {
                 dispatch({
                     type: ERROR_OCCURRED,
                     error: response,
-                    errorOccurred: true
+                    errorOccurred: true,
+                    stateKey
                 });
             }
 

--- a/src/actions/plugins/selection/ModelActions.js
+++ b/src/actions/plugins/selection/ModelActions.js
@@ -5,43 +5,45 @@ import {
     NO_EVENT
 } from '../../../constants/ActionTypes';
 
-import { keyFromObject } from '../../../util/keyGenerator';
+import { keyGenerator } from '../../../util/keyGenerator';
 
-export function selectAll(data) {
-    const keys = data.currentRecords.map(keyFromObject);
+export function selectAll({ data, stateKey }) {
+    const keys = data.currentRecords.map((row, i) => keyGenerator('row', i));
+
     const selection = keys.reduce((obj, k) => {
         obj[k] = true;
         return obj;
     }, {});
-
-    return { type: SELECT_ALL, selection };
+    return { type: SELECT_ALL, selection, stateKey };
 }
 
-export function deselectAll() {
-    return { type: DESELECT_ALL };
+export function deselectAll({ stateKey }) {
+    return { type: DESELECT_ALL, stateKey };
 }
 
-export function setSelection(id, selectionModelDefaults, modes) {
+export function setSelection({
+    id, defaults, modes, stateKey
+}) {
 
-    const allowDeselect = selectionModelDefaults.allowDeselect;
-    const clearSelections = selectionModelDefaults.mode === modes.checkboxSingle
-        || selectionModelDefaults.mode === modes.single;
+    const allowDeselect = defaults.allowDeselect;
+    const clearSelections = defaults.mode === modes.checkboxSingle
+        || defaults.mode === modes.single;
 
-    if (!selectionModelDefaults.enabled) {
+    if (!defaults.enabled) {
         console.warn('Selection model has been disabled');
         return { type: NO_EVENT };
     }
 
-    if (selectionModelDefaults.mode === modes.single) {
-        return { type: SET_SELECTION, id, clearSelections, allowDeselect };
+    if (defaults.mode === modes.single) {
+        return { type: SET_SELECTION, id, clearSelections, allowDeselect, stateKey };
     }
 
-    else if (selectionModelDefaults.mode === modes.multi) {
-        return { type: SET_SELECTION, id, allowDeselect };
+    else if (defaults.mode === modes.multi) {
+        return { type: SET_SELECTION, id, allowDeselect, stateKey };
     }
 
-    else if (selectionModelDefaults.mode === modes.checkboxSingle
-        || selectionModelDefaults.mode === modes.checkboxMulti) {
-        return { type: SET_SELECTION, id, clearSelections, allowDeselect };
+    else if (defaults.mode === modes.checkboxSingle
+        || defaults.mode === modes.checkboxMulti) {
+        return { type: SET_SELECTION, id, clearSelections, allowDeselect, stateKey };
     }
 }

--- a/src/components/core/ColumnManager.js
+++ b/src/components/core/ColumnManager.js
@@ -8,7 +8,9 @@ import sorter from '../../util/sorter';
 
 export default class ColumnManager {
 
-    init({plugins, store, events, selModel, editor, columns, reducerKeys, dataSource}) {
+    init({
+        plugins, store, events, selModel, editor, columns, dataSource
+    }) {
 
         const defaults = {
             defaultColumnWidth: `${100 / columns.length}%`,
@@ -51,9 +53,11 @@ export default class ColumnManager {
         this.config = config;
     }
 
-    doSort(method, column, direction, dataSource, pagerState) {
+    doSort({
+        method, column, direction, dataSource, pagerState, stateKey
+    }) {
 
-        const propName = camelize(column.name);
+        const propName = column.dataIndex || camelize(column.name);
 
         const sortParams = {
             sort: {
@@ -62,24 +66,43 @@ export default class ColumnManager {
             }
         };
 
-        const pageIndex = pagerState && pagerState.pageIndex ? pagerState.pageIndex : 0;
+        const pageIndex = pagerState
+            && pagerState.pageIndex
+            ? pagerState.pageIndex
+            : 0;
 
-        const pageSize = pagerState && pagerState.pageSize ? pagerState.pageSize : DEFAULT_PAGE_SIZE;
+        const pageSize = pagerState
+            && pagerState.pageSize
+            ? pagerState.pageSize
+            : DEFAULT_PAGE_SIZE;
 
         if (method === SORT_METHODS.LOCAL) {
             this.store.dispatch(
-                doLocalSort(
-                    this.sorter.sortBy(column.name, direction, dataSource)));
+                doLocalSort({
+                    data: this.sorter.sortBy(
+                        column.name, direction, dataSource
+                    ),
+                    stateKey
+                })
+            );
         }
 
         else {
             this.store.dispatch(
-                doRemoteSort(this.config.sortable.sortingSource, pageIndex, pageSize, sortParams
-            ));
+                doRemoteSort({
+                    dataSource: this.config.sortable.sortingSource,
+                    pageIndex,
+                    pageSize,
+                    sortParams,
+                    stateKey
+                })
+            );
         }
     }
 
-    addActionColumn(cells, type, id, reducerKeys, rowData, rowIndex) {
+    addActionColumn({
+        cells, type, id, reducerKeys, rowData, rowIndex, stateKey
+    }) {
 
         const { GRID_ACTIONS } = this.plugins;
         const cellsCopy = cells;
@@ -94,6 +117,7 @@ export default class ColumnManager {
             editor: this.editor,
             reducerKeys,
             selModel: this.selModel,
+            stateKey,
             headerActionItemBuilder: this.config.headerActionItemBuilder,
             key: keyFromObject(cells, ['row', 'actionhandler'])
         };

--- a/src/components/core/menu/Menu.jsx
+++ b/src/components/core/menu/Menu.jsx
@@ -11,6 +11,7 @@ class Menu extends Component {
     static propTypes = {
         menu: React.PropTypes.array,
         metaData: React.PropTypes.object,
+        stateKey: React.PropTypes.string,
         store: React.PropTypes.object
     };
 
@@ -20,7 +21,7 @@ class Menu extends Component {
 
     getMenuItem(item) {
 
-        const { metaData, store } = this.props;
+        const { metaData, stateKey, store } = this.props;
 
         if (!item.$$typeof) {
             const menuItemProps = {
@@ -28,6 +29,7 @@ class Menu extends Component {
                 metaData,
                 type: item.type,
                 key: keyFromObject(item),
+                stateKey,
                 store
             };
 

--- a/src/components/core/menu/MenuItem.jsx
+++ b/src/components/core/menu/MenuItem.jsx
@@ -11,6 +11,7 @@ class MenuItem extends Component {
         data: React.PropTypes.object,
         menuItemsTypes: React.PropTypes.object,
         metaData: React.PropTypes.object,
+        stateKey: React.PropTypes.string,
         store: React.PropTypes.object
     };
 
@@ -21,7 +22,7 @@ class MenuItem extends Component {
         metaData: {}
     };
 
-    handleMenuItemClick(data, metaData, reactEvent) {
+    handleMenuItemClick(data, metaData, stateKey, reactEvent) {
         if (reactEvent && reactEvent.stopPropagation) {
             reactEvent.stopPropagation();
         }
@@ -32,7 +33,7 @@ class MenuItem extends Component {
         const { store } = this.props;
 
         if (dismiss) {
-            store.dispatch(hideMenu());
+            store.dispatch(hideMenu({ stateKey }));
         }
 
         if (data.EVENT_HANDLER) {
@@ -58,11 +59,11 @@ class MenuItem extends Component {
     }
 
     render() {
-        const { data, metaData, menuItemsTypes } = this.props;
+        const { data, metaData, menuItemsTypes, stateKey } = this.props;
 
         const menuItemProps = {
             className: prefix(CLASS_NAMES.GRID_ACTIONS.MENU.ITEM),
-            onClick: this.handleMenuItemClick.bind(this, data, metaData)
+            onClick: this.handleMenuItemClick.bind(this, data, metaData, stateKey)
         };
 
         const checkboxComponent =

--- a/src/components/layout/Cell.jsx
+++ b/src/components/layout/Cell.jsx
@@ -10,7 +10,7 @@ import { elementContains } from '../../util/elementContains';
 import { CLASS_NAMES } from '../../constants/GridConstants';
 
 export const Cell = (
-    { cellData, columns, editor, editorState, events, index, rowData, rowIndex, rowId, selectionModel, store }
+    { cellData, columns, editor, editorState, events, index, rowData, rowIndex, rowId, stateKey, selectionModel, store }
 ) => {
 
     const isEditable = editorState
@@ -24,7 +24,7 @@ export const Cell = (
             : null;
 
     const cellClickArguments = {
-        events, columns, cellData, editor, editorState, rowIndex, rowData, rowId, selectionModel, store
+        events, columns, cellData, editor, editorState, rowIndex, rowData, rowId, selectionModel, stateKey, store
     };
 
     const cellProps = {
@@ -38,7 +38,7 @@ export const Cell = (
         cellProps.style.display = 'none';
     }
 
-    const cellHTML = getCellHTML(cellData, editorState, isEditable, columns, index, rowId, store);
+    const cellHTML = getCellHTML(cellData, editorState, isEditable, columns, index, rowId, stateKey, store);
 
     return (
         <td { ...cellProps }>
@@ -47,7 +47,7 @@ export const Cell = (
         );
 };
 
-export const getCellHTML = (cellData, editorState, isEditable, columns, index, rowId, store) => {
+export const getCellHTML = (cellData, editorState, isEditable, columns, index, rowId, stateKey, store) => {
 
     const editorProps = {
         cellData,
@@ -56,7 +56,8 @@ export const getCellHTML = (cellData, editorState, isEditable, columns, index, r
         index,
         isEditable,
         rowId,
-        store
+        store,
+        stateKey
     };
 
     return (
@@ -65,7 +66,7 @@ export const getCellHTML = (cellData, editorState, isEditable, columns, index, r
 };
 
 export const handleClick = (
-    { events, columns, cellData, editor, editorState, rowIndex, rowData, rowId, selectionModel, store }, reactEvent
+    { events, columns, cellData, editor, editorState, rowIndex, rowData, rowId, selectionModel, stateKey, store }, reactEvent
 ) => {
 
     if (reactEvent.target && elementContains(reactEvent.target, prefix(CLASS_NAMES.EDITED_CELL))) {
@@ -75,11 +76,15 @@ export const handleClick = (
     if (selectionModel.defaults.editEvent === selectionModel.eventTypes.singleclick) {
 
         if (!editorState || Object.keys(editorState).length === 0) {
-            handleEditClick(editor, store, rowId, rowData, rowIndex, columns, { reactEvent });
+            handleEditClick(
+                editor, store, rowId, rowData, rowIndex, columns, stateKey, { reactEvent }
+            );
         }
 
         else if (editorState && editorState.row && editorState.row.rowIndex !== rowIndex) {
-            handleEditClick(editor, store, rowId, rowData, rowIndex, columns, { reactEvent });
+            handleEditClick(
+                editor, store, rowId, rowData, rowIndex, columns, stateKey, { reactEvent }
+            );
         }
     }
 
@@ -89,7 +94,7 @@ export const handleClick = (
 };
 
 export const handleDoubleClick = (
-    { events, columns, cellData, editor, editorState, rowIndex, rowData, rowId, selectionModel, store }, reactEvent
+    { events, columns, cellData, editor, editorState, rowIndex, rowData, rowId, selectionModel, stateKey, store }, reactEvent
 ) => {
 
     if (reactEvent.target && elementContains(reactEvent.target, prefix(CLASS_NAMES.EDITED_CELL))) {
@@ -120,7 +125,7 @@ Cell.propTypes = {
 
 function mapStateToProps(state, props) {
     return {
-        editorState: stateGetter(state, props, 'editor', 'editorState')
+        editorState: stateGetter(state, props, 'editor', props.stateKey)
     };
 }
 

--- a/src/components/layout/FixedHeader.jsx
+++ b/src/components/layout/FixedHeader.jsx
@@ -25,6 +25,7 @@ class FixedHeader extends Component {
         plugins: PropTypes.object,
         reducerKeys: PropTypes.object,
         selectionModel: PropTypes.object,
+        stateKey: PropTypes.string,
         store: PropTypes.object
     };
 
@@ -41,6 +42,7 @@ class FixedHeader extends Component {
             dataSource,
             reducerKeys,
             selectionModel,
+            stateKey,
             store,
             pager,
             plugins
@@ -59,6 +61,7 @@ class FixedHeader extends Component {
                 index: i,
                 pager,
                 store,
+                stateKey,
                 visibleColumns,
                 key: `fixed-header-${i}`
             };
@@ -78,10 +81,16 @@ class FixedHeader extends Component {
         };
 
         if (selectionModel) {
-            selectionModel.updateCells(headers, columns, 'header');
+            selectionModel.updateCells(headers, columns, 'header', null, stateKey);
         }
 
-        columnManager.addActionColumn(headers, 'header', keyFromObject(columns), reducerKeys);
+        columnManager.addActionColumn({
+            cells: headers,
+            type: 'header',
+            id: keyFromObject(headers),
+            reducerKeys,
+            stateKey
+        });
 
         addEmptyInsert(headers, visibleColumns, plugins);
 
@@ -134,7 +143,7 @@ export const addEmptyInsert = (headers, visibleColumns, plugins) => {
 
 };
 
-export const handleDrag = (scope, columns, id, columnManager, store, nextColumnKey, reactEvent) => {
+export const handleDrag = (scope, columns, id, columnManager, store, nextColumnKey, stateKey, reactEvent) => {
 
     const header = reactEvent.target.parentElement.parentElement;
     const columnNode = reactEvent.target.parentElement;
@@ -173,7 +182,7 @@ export const handleDrag = (scope, columns, id, columnManager, store, nextColumnK
     store.dispatch(resizeColumns(width, id, {
         id: nextColumnKey,
         width: nextColWidth
-    }, columns));
+    }, columns, stateKey));
 
 };
 
@@ -185,9 +194,9 @@ export const handleColumnClick = (col) => {
 
 function mapStateToProps(state, props) {
     return {
-        columnState: stateGetter(state, props, 'grid', 'gridState'),
-        dataSource: stateGetter(state, props, 'dataSource', 'gridData'),
-        pager: stateGetter(state, props, 'pager', 'pagerState')
+        columnState: stateGetter(state, props, 'grid', props.stateKey),
+        dataSource: stateGetter(state, props, 'dataSource', props.stateKey),
+        pager: stateGetter(state, props, 'pager', props.stateKey)
     };
 }
 

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -23,6 +23,7 @@ class Header extends Component {
         plugins: PropTypes.object,
         reducerKeys: PropTypes.object,
         selectionModel: PropTypes.object,
+        stateKey: PropTypes.string,
         store: PropTypes.object,
         visible: PropTypes.bool
     };
@@ -41,6 +42,7 @@ class Header extends Component {
             selectionModel,
             reducerKeys,
             store,
+            stateKey,
             pager,
             plugins,
             visible
@@ -77,10 +79,16 @@ class Header extends Component {
         };
 
         if (selectionModel) {
-            selectionModel.updateCells(headers, columns, 'header');
+            selectionModel.updateCells(headers, columns, 'header', stateKey);
         }
 
-        columnManager.addActionColumn(headers, 'header', keyFromObject(headers), reducerKeys);
+        columnManager.addActionColumn({
+            cells: headers,
+            type: 'header',
+            id: keyFromObject(headers),
+            reducerKeys,
+            stateKey
+        });
 
         addEmptyInsert(headers, visibleColumns, plugins);
 
@@ -130,9 +138,9 @@ export const handleColumnClick = (col) => {
 
 function mapStateToProps(state, props) {
     return {
-        columnState: stateGetter(state, props, 'grid', 'gridState'),
-        dataSource: stateGetter(state, props, 'dataSource', 'gridData'),
-        pager: stateGetter(state, props, 'pager', 'pagerState')
+        columnState: stateGetter(state, props, 'grid', props.stateKey),
+        dataSource: stateGetter(state, props, 'dataSource', props.stateKey),
+        pager: stateGetter(state, props, 'pager', props.stateKey)
     };
 }
 

--- a/src/components/layout/cell/Editor.jsx
+++ b/src/components/layout/cell/Editor.jsx
@@ -5,7 +5,9 @@ import { prefix } from './../../../util/prefix';
 
 const wrapperCls = prefix(CLASS_NAMES.EDITOR.INLINE.INPUT_WRAPPER);
 
-export const Editor = ({ cellData, columns, editorState, index, isEditable, rowId, store }) => {
+export const Editor = ({
+    cellData, columns, editorState, index, isEditable, rowId, stateKey, store
+}) => {
 
     let colName = columns
         && columns[index]
@@ -41,7 +43,8 @@ export const Editor = ({ cellData, columns, editorState, index, isEditable, rowI
                 rowId,
                 row: editorState.row,
                 columnIndex: index,
-                value: value
+                value: value,
+                stateKey
             }
         );
 
@@ -56,23 +59,36 @@ export const Editor = ({ cellData, columns, editorState, index, isEditable, rowI
         return (
             <span { ...{ className: wrapperCls } }>
                 <Input {
-                    ...{ column: columns[index], columns, editorState, cellData, rowId, store } }
+                        ...{
+                            column: columns[index],
+                            columns,
+                            editorState,
+                            cellData,
+                            rowId,
+                            stateKey,
+                            store
+                        }
+                    }
                 />
             </span>
             );
     }
 
     return (
-        <span { ...{ className: prefix(CLASS_NAMES.INACTIVE_CLASS) } } > { cellData } </span>
+        <span { ...{ className: prefix(CLASS_NAMES.INACTIVE_CLASS) } } >
+            { cellData }
+        </span>
         );
 };
 
 Editor.propTypes = {
     cellData: PropTypes.any,
     columns: PropTypes.array,
+    editorState: PropTypes.object,
     index: PropTypes.number,
     isEditable: PropTypes.bool,
     rowId: PropTypes.string,
+    stateKey: PropTypes.string,
     store: PropTypes.object
 };
 

--- a/src/components/layout/cell/Input.jsx
+++ b/src/components/layout/cell/Input.jsx
@@ -2,9 +2,15 @@ import React, { PropTypes } from 'react';
 
 import { updateCellValue } from './../../../actions/plugins/editor/EditorActions';
 
-export const Input = (
-    { cellData, column, columns, editorState, rowId, store }
-) => {
+export const Input = ({
+    cellData,
+    column,
+    columns,
+    editorState,
+    rowId,
+    stateKey,
+    store
+}) => {
 
     const colName = column
         && column.dataIndex
@@ -30,7 +36,7 @@ export const Input = (
 
     const inputProps = {
         disabled,
-        onChange: handleChange.bind(null, column, columns, rowId, store),
+        onChange: handleChange.bind(null, column, columns, rowId, stateKey, store),
         type: 'text',
         value: value,
         placeholder
@@ -42,17 +48,25 @@ export const Input = (
 };
 
 export const handleChange = (
-    columnDefinition, columns, rowId, store, reactEvent
+    columnDefinition, columns, rowId, stateKey, store, reactEvent
 ) => {
     store.dispatch(
-        updateCellValue(
-            reactEvent.target.value, columnDefinition.dataIndex, columnDefinition, columns
-        )
+        updateCellValue({
+            value: reactEvent.target.value,
+            name: columnDefinition.dataIndex,
+            column: columnDefinition,
+            columns,
+            stateKey
+        })
     );
 };
 
 Input.propTypes = {
     cellData: PropTypes.any,
     column: PropTypes.object,
+    columns: PropTypes.array,
+    editorState: PropTypes.object,
+    rowId: PropTypes.string,
+    stateKey: PropTypes.string,
     store: PropTypes.object
 };

--- a/src/components/layout/header/column/SortHandle.jsx
+++ b/src/components/layout/header/column/SortHandle.jsx
@@ -6,7 +6,9 @@ import { CLASS_NAMES } from './../../../../constants/GridConstants';
 export const SortHandle = ({ direction, sortHandleCls }) => {
 
     const handleProps = {
-        className: prefix(CLASS_NAMES.SORT_HANDLE, direction.toLowerCase(), sortHandleCls)
+        className: prefix(
+            CLASS_NAMES.SORT_HANDLE, direction.toLowerCase(), sortHandleCls
+        )
     };
 
     return (
@@ -19,6 +21,8 @@ SortHandle.propTypes = {
     columnManager: PropTypes.object,
     columns: PropTypes.array,
     dataSource: PropTypes.object,
+    direction: PropTypes.string,
     pager: PropTypes.object,
+    sortHandleCls: PropTypes.string,
     store: PropTypes.object
 };

--- a/src/components/plugins/ajax/Request.js
+++ b/src/components/plugins/ajax/Request.js
@@ -29,7 +29,9 @@ function api(config) {
 function setRequestHeaders(request, config) {
 
     if (!config.headers || !config.headers.contentType) {
-        request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        request.setRequestHeader(
+            'Content-Type', 'application/x-www-form-urlencoded'
+        );
     }
 
     if (!config.headers) {
@@ -44,10 +46,18 @@ function setRequestHeaders(request, config) {
 function addAjaxEvents(request, config, resolver) {
 
     const getResponse = () => {
-        resolver(JSON.parse(request.responseText));
+        try {
+            resolver(JSON.parse(request.responseText));
+        }
+
+        catch (e) {
+            console.log(e);
+        }
     };
 
-    request.addEventListener('load', getResponse.bind(config.onSuccess, config.onSuccess));
+    request.addEventListener(
+        'load', getResponse.bind(config.onSuccess, config.onSuccess)
+    );
 }
 
 function buildQueryString(config) {

--- a/src/components/plugins/bulkactions/Toolbar.jsx
+++ b/src/components/plugins/bulkactions/Toolbar.jsx
@@ -15,6 +15,7 @@ class BulkActionToolbar extends Component {
         plugins: PropTypes.object.isRequired,
         selectedRows: PropTypes.object,
         selectionModel: PropTypes.object.isRequired,
+        stateKey: PropTypes.string,
         store: PropTypes.object.isRequired
     };
 
@@ -24,38 +25,38 @@ class BulkActionToolbar extends Component {
     }
 
     componentDidUpdate() {
-        const { store, bulkActionState, selectedRows } = this.props;
+        const { store, stateKey, bulkActionState, selectedRows } = this.props;
         const isRemoved = bulkActionState && bulkActionState.isRemoved;
         const totalCount = getTotalSelection(selectedRows);
 
         if (totalCount === 0 && !isRemoved) {
             clearTimeout(this.removeTimeout);
             this.removeTimeout = setTimeout(() => {
-                store.dispatch(removeToolbar(true));
+                store.dispatch(removeToolbar({ state: true, stateKey }));
             }, 300);
         }
 
         else if (totalCount > 0 && isRemoved) {
-            store.dispatch(removeToolbar(false));
+            store.dispatch(removeToolbar({ state: false, stateKey }));
         }
     }
 
     handleChange(reactEvent) {
 
-        const { store, dataSource } = this.props;
+        const { stateKey, store, dataSource } = this.props;
 
         if (reactEvent.target && reactEvent.target.checked) {
-            store.dispatch(selectAll(dataSource));
+            store.dispatch(selectAll({ data: dataSource, stateKey }));
         }
 
         else {
-            store.dispatch(deselectAll());
+            store.dispatch(deselectAll({ stateKey }));
         }
     }
 
     render() {
 
-        const { bulkActionState, selectedRows, plugins } = this.props;
+        const { bulkActionState, selectedRows, stateKey, plugins } = this.props;
 
         const toolbar = plugins
             && plugins.BULK_ACTIONS
@@ -127,9 +128,9 @@ export const getAction = (action) => {
 function mapStateToProps(state, props) {
 
     return {
-        dataSource: stateGetter(state, props, 'dataSource', 'gridData'),
-        selectedRows: stateGetter(state, props, 'selection', 'selectedRows'),
-        bulkActionState: stateGetter(state, props, 'bulkaction', 'bulkActionState')
+        dataSource: stateGetter(state, props, 'dataSource', props.stateKey),
+        selectedRows: stateGetter(state, props, 'selection', props.stateKey),
+        bulkActionState: stateGetter(state, props, 'bulkaction', props.stateKey)
     };
 }
 

--- a/src/components/plugins/editor/Inline.jsx
+++ b/src/components/plugins/editor/Inline.jsx
@@ -32,7 +32,7 @@ export class Inline extends Component {
 
     render() {
 
-        const { BUTTON_TYPES, editorState, events, store } = this.props;
+        const { BUTTON_TYPES, editorState, events, stateKey, store } = this.props;
 
         let top = -100;
 
@@ -55,8 +55,8 @@ export class Inline extends Component {
         return (
             <div { ...inlineEditorProps }>
                 <span { ...buttonContainerProps }>
-                    <Button { ...{ type: BUTTON_TYPES.SAVE, editorState, events, store } }/>
-                    <Button { ...{ type: BUTTON_TYPES.CANCEL, editorState, events, store } }/>
+                    <Button { ...{ type: BUTTON_TYPES.SAVE, editorState, events, stateKey, store } }/>
+                    <Button { ...{ type: BUTTON_TYPES.CANCEL, editorState, events, stateKey, store } }/>
                 </span>
             </div>
         );
@@ -65,7 +65,9 @@ export class Inline extends Component {
 }
 
 export const focusFirstEditor = () => {
-    const input = document.querySelector('.react-grid-edit .react-grid-editor-wrapper input:enabled');
+    const input = document.querySelector(
+        '.react-grid-edit .react-grid-editor-wrapper input:enabled'
+    );
 
     if (input && input.focus) {
         input.focus();
@@ -83,6 +85,7 @@ Inline.propTypes = {
     editorState: PropTypes.object,
     events: PropTypes.object,
     reducerKeys: PropTypes.object,
+    stateKey: PropTypes.string,
     store: PropTypes.object
 };
 
@@ -95,8 +98,8 @@ Inline.defaultProps = {
 
 function mapStateToProps(state, props) {
     return {
-        errorHandler: stateGetter(state, props, 'errorhandler', 'errorState'),
-        editorState: stateGetter(state, props, 'editor', 'editorState')
+        errorHandler: stateGetter(state, props, 'errorhandler', props.stateKey),
+        editorState: stateGetter(state, props, 'editor', props.stateKey)
     };
 }
 

--- a/src/components/plugins/editor/Manager.js
+++ b/src/components/plugins/editor/Manager.js
@@ -3,7 +3,7 @@ import Inline from './Inline.jsx';
 
 export default class Manager {
 
-    init(plugins, store) {
+    init(plugins, stateKey, store) {
 
         const defaults = {
             type: 'inline',
@@ -18,6 +18,7 @@ export default class Manager {
         const config = plugins && plugins.EDITOR
             ? Object.assign(defaults, plugins.EDITOR) : defaults;
 
+        this.stateKey = stateKey;
         this.config = config;
         this.editModes = editModes;
         this.store = store;
@@ -30,6 +31,7 @@ export default class Manager {
             config: this.config,
             reducerKeys,
             store,
+            stateKey: this.stateKey,
             events
         };
 

--- a/src/components/plugins/editor/inline/Button.jsx
+++ b/src/components/plugins/editor/inline/Button.jsx
@@ -2,17 +2,37 @@ import React, { PropTypes } from 'react';
 
 import { prefix } from '../../../../util/prefix';
 import { CLASS_NAMES } from '../../../../constants/GridConstants';
-import { dismissEditor } from './../../../../actions/plugins/editor/EditorActions';
+import {
+    dismissEditor
+} from './../../../../actions/plugins/editor/EditorActions';
 import { saveRow } from './../../../../actions/plugins/editor/EditorActions';
 
-export const Button = ({ BUTTON_TYPES, saveText, cancelText, editorState, events, store, type }) => {
+export const Button = ({
+    BUTTON_TYPES,
+    saveText,
+    cancelText,
+    editorState,
+    events,
+    stateKey,
+    store,
+    type
+}) => {
 
     const text = type === BUTTON_TYPES.SAVE ? saveText : cancelText;
 
     const buttonProps = {
-        onClick: onButtonClick.bind(this, BUTTON_TYPES, editorState, events, type, store),
+        onClick: onButtonClick.bind(
+            this,
+            BUTTON_TYPES,
+            editorState,
+            events,
+            type,
+            stateKey,
+            store
+        ),
         className: type === BUTTON_TYPES.SAVE
-            ? prefix(CLASS_NAMES.EDITOR.INLINE.SAVE_BUTTON) : prefix(CLASS_NAMES.EDITOR.INLINE.CANCEL_BUTTON)
+            ? prefix(CLASS_NAMES.EDITOR.INLINE.SAVE_BUTTON)
+            : prefix(CLASS_NAMES.EDITOR.INLINE.CANCEL_BUTTON)
     };
 
     if (type === BUTTON_TYPES.SAVE
@@ -47,15 +67,23 @@ Button.defaultProps = {
     saveText: 'Save'
 };
 
-export const onButtonClick = (BUTTON_TYPES, editorState, events, type, store) => {
+export const onButtonClick = (
+    BUTTON_TYPES, editorState, events, type, stateKey, store
+) => {
 
     if (type === BUTTON_TYPES.CANCEL) {
-        store.dispatch(dismissEditor());
+        store.dispatch(dismissEditor({ stateKey }));
     }
 
     else if (type === BUTTON_TYPES.SAVE) {
 
-        store.dispatch(saveRow(editorState.row.values, editorState.row.rowIndex));
+        store.dispatch(
+            saveRow({
+                values: editorState.row.values,
+                rowIndex: editorState.row.rowIndex,
+                stateKey
+            })
+        );
 
         if (events.HANDLE_AFTER_INLINE_EDITOR_SAVE) {
             const values = editorState.row.values;
@@ -65,6 +93,6 @@ export const onButtonClick = (BUTTON_TYPES, editorState, events, type, store) =>
             });
         }
 
-        store.dispatch(dismissEditor());
+        store.dispatch(dismissEditor({ stateKey }));
     }
 };

--- a/src/components/plugins/filtercontainer/Menu.jsx
+++ b/src/components/plugins/filtercontainer/Menu.jsx
@@ -8,7 +8,7 @@ import { prefix } from '../../../util/prefix';
 import { stateGetter } from '../../../util/stateGetter';
 import { CLASS_NAMES, FILTER_METHODS } from '../../../constants/GridConstants';
 
-export const FilterMenu = ({ buttonText, buttonTypes, dataSource, menuTitle, filter, plugins, pager, store }) => {
+export const FilterMenu = ({ buttonText, buttonTypes, dataSource, menuTitle, filter, plugins, pager, stateKey, store }) => {
 
     const menuContainerProps = {
         className: prefix(CLASS_NAMES.FILTER_CONTAINER.MENU.CONTAINER)
@@ -26,9 +26,9 @@ export const FilterMenu = ({ buttonText, buttonTypes, dataSource, menuTitle, fil
     const inputs = plugins.FILTER_CONTAINER.fields
         && plugins.FILTER_CONTAINER.fields.length > 0
         ? plugins.FILTER_CONTAINER.fields.map(
-                (field) => <Input { ...{ field, filter, store } }/>
+                (field) => <Input { ...{ field, filter, stateKey, store } }/>
             )
-        : null;
+        : null; 
 
     const buttonProps = {
         buttonText,
@@ -49,8 +49,8 @@ export const FilterMenu = ({ buttonText, buttonTypes, dataSource, menuTitle, fil
                 { inputs }
             </div>
             <div { ...buttonContainerProps }>
-                <Button { ...buttonProps } { ...{ type: buttonTypes.CANCEL } } />
-                <Button { ...buttonProps } { ...{ type: buttonTypes.SUBMIT } } />
+                <Button { ...buttonProps } { ...{ stateKey, type: buttonTypes.CANCEL } } />
+                <Button { ...buttonProps } { ...{ stateKey, type: buttonTypes.SUBMIT } } />
             </div>
         </div>
         );
@@ -59,9 +59,12 @@ export const FilterMenu = ({ buttonText, buttonTypes, dataSource, menuTitle, fil
 FilterMenu.propTypes = {
     buttonText: PropTypes.object,
     buttonTypes: PropTypes.object,
+    dataSource: PropTypes.object,
     filter: PropTypes.string,
     menuTitle: PropTypes.string.isRequired,
+    pager: PropTypes.object,
     plugins: PropTypes.object.isRequired,
+    stateKey: PropTypes.string,
     store: PropTypes.object.isRequired
 };
 
@@ -84,10 +87,10 @@ FilterMenu.defaultProps = {
 function mapStateToProps(state, props) {
 
     return {
-        dataSource: stateGetter(state, props, 'dataSource', 'gridData'),
-        selectedRows: stateGetter(state, props, 'selection', 'selectedRows'),
-        filter: stateGetter(state, props, 'filter', 'filterState'),
-        pager: stateGetter(state, props, 'pager', 'pagerState')
+        dataSource: stateGetter(state, props, 'dataSource', props.stateKey),
+        selectedRows: stateGetter(state, props, 'selection', props.stateKey),
+        filter: stateGetter(state, props, 'filter', props.stateKey),
+        pager: stateGetter(state, props, 'pager', props.stateKey)
     };
 }
 

--- a/src/components/plugins/filtercontainer/Toolbar.jsx
+++ b/src/components/plugins/filtercontainer/Toolbar.jsx
@@ -11,14 +11,26 @@ import { prefix } from '../../../util/prefix';
 
 import filterUtils from '../../../util/filterUtils';
 import { stateGetter } from '../../../util/stateGetter';
-import { CLASS_NAMES, FILTER_METHODS, KEYBOARD_MAP } from '../../../constants/GridConstants';
+import {
+    CLASS_NAMES, FILTER_METHODS, KEYBOARD_MAP
+} from '../../../constants/GridConstants';
 import { setFilter,
     doLocalFilter,
     doRemoteFilter
 } from '../../../actions/plugins/filter/FilterActions';
 
-export const FilterToolbar = ({ columnManager, dataSource, defaultSortMethod, filter,
-    placeHolderText, pager, pageSize, plugins, store}) => {
+export const FilterToolbar = ({
+    columnManager,
+    dataSource,
+    defaultSortMethod,
+    filter,
+    placeHolderText,
+    pager,
+    pageSize,
+    plugins,
+    stateKey,
+    store
+}) => {
 
     const customComponent = plugins
         && plugins.FILTER_CONTAINER
@@ -33,8 +45,18 @@ export const FilterToolbar = ({ columnManager, dataSource, defaultSortMethod, fi
     const toolbar = plugins
         && plugins.FILTER_CONTAINER
         && plugins.FILTER_CONTAINER.enabled
-        ? getToolbar(columnManager, dataSource, defaultSortMethod, filter,
-            placeHolderText, pager, pageSize, plugins, store)
+        ? getToolbar(
+            columnManager,
+            dataSource,
+            defaultSortMethod,
+            filter,
+            placeHolderText,
+            pager,
+            pageSize,
+            plugins,
+            stateKey,
+            store
+        )
         : <div />;
 
     return toolbar;
@@ -58,8 +80,18 @@ FilterToolbar.defaultProps = {
     placeHolderText: 'Search'
 };
 
-export const getToolbar = (columnManager, dataSource, defaultSortMethod,
-    filter, placeHolderText, pager, pageSize, plugins, store) => {
+export const getToolbar = (
+    columnManager,
+    dataSource,
+    defaultSortMethod,
+    filter,
+    placeHolderText,
+    pager,
+    pageSize,
+    plugins,
+    stateKey,
+    store
+) => {
 
     const dataUri = columnManager.config.dataSource || '';
 
@@ -85,21 +117,32 @@ export const getToolbar = (columnManager, dataSource, defaultSortMethod,
     }
 
     const applicableButton = inputValue && inputValue.length > 0
-        ? <ClearButton { ...{ dataUri, method, store } } />
+        ? <ClearButton { ...{ dataUri, method, stateKey, store } } />
         : <SearchButton />;
 
     const filterMenuButton = plugins.FILTER_CONTAINER.enableFilterMenu
-        ? <FilterButton { ...{ filter, filterMenuShown, store } }/>
+        ? <FilterButton { ...{ filter, filterMenuShown, stateKey, store } }/>
         : null;
 
     const filterMenu = filterMenuShown
-        ? <FilterMenu { ...{ store, plugins } } />
+        ? <FilterMenu { ...{ store, stateKey, plugins } } />
         : null;
 
     return (
         <div { ...{ className: prefix(CLASS_NAMES.FILTER_CONTAINER.CONTAINER) } }>
-            <Input { ...{ dataSource, method, placeHolderText,
-    inputValue, plugins, pager, pageSize, store } }
+            <Input { 
+                    ...{ 
+                        dataSource,
+                        method,
+                        placeHolderText,
+                        inputValue,
+                        plugins,
+                        pager,
+                        pageSize,
+                        stateKey,
+                        store
+                    }
+                }
             />
             <div { ...{ className: prefix(CLASS_NAMES.FILTER_CONTAINER.BUTTON_CONTAINER) } }>
                 { applicableButton }
@@ -148,10 +191,10 @@ export const handleKeyUp = (value, method, dataSource, plugins, pager, pageSize,
 function mapStateToProps(state, props) {
 
     return {
-        dataSource: stateGetter(state, props, 'dataSource', 'gridData'),
-        selectedRows: stateGetter(state, props, 'selection', 'selectedRows'),
-        filter: stateGetter(state, props, 'filter', 'filterState'),
-        pager: stateGetter(state, props, 'pager', 'pagerState')
+        dataSource: stateGetter(state, props, 'dataSource', props.stateKey),
+        selectedRows: stateGetter(state, props, 'selection', props.stateKey),
+        filter: stateGetter(state, props, 'filter', props.stateKey),
+        pager: stateGetter(state, props, 'pager',  props.stateKey)
     };
 }
 

--- a/src/components/plugins/filtercontainer/menu/Button.jsx
+++ b/src/components/plugins/filtercontainer/menu/Button.jsx
@@ -12,14 +12,14 @@ import {
 
 export const Button = ({
     buttonText, buttonTypes, dataSource, filter,
-    plugins, pager, type, store }) => {
+    plugins, pager, type, stateKey, store }) => {
 
     const buttonProps = {
         text: buttonText[type],
         className: prefix(CLASS_NAMES.FILTER_CONTAINER.MENU.BUTTON,
         type === buttonTypes.CANCEL ? CLASS_NAMES.SECONDARY_CLASS : ''),
         onClick: handleButtonClick.bind(this, buttonTypes, dataSource,
-            filter, plugins, pager, type, store)
+            filter, plugins, pager, type, stateKey, store)
     };
 
     return (
@@ -45,7 +45,7 @@ Button.defaultProps = {
 
 };
 
-export const handleButtonClick = (buttonTypes, dataSource, filter, plugins, pager, type, store) => {
+export const handleButtonClick = (buttonTypes, dataSource, filter, plugins, pager, type, stateKey, store) => {
 
     const method = plugins.FILTER_CONTAINER.method
         ? plugins.FILTER_CONTAINER.method.toUpperCase()
@@ -60,20 +60,31 @@ export const handleButtonClick = (buttonTypes, dataSource, filter, plugins, page
     }
 
     if (type === buttonTypes.CANCEL) {
-        store.dispatch(showFilterMenu(true, true));
-        store.dispatch(clearFilterLocal(dataSource));
+        store.dispatch(showFilterMenu({ value: true, stateKey }));
+        store.dispatch(clearFilterLocal({ dataSource, stateKey }));
     }
 
     else if (type === buttonTypes.SUBMIT) {
 
         if (method === FILTER_METHODS.LOCAL) {
-            store.dispatch(doLocalFilter(
-                filterUtils.byMenu(filter.filterMenuValues, dataSource))
+            store.dispatch(
+                doLocalFilter({
+                    data: filterUtils.byMenu(filter.filterMenuValues, dataSource),
+                    stateKey
+                })
             );
         }
 
         else if (method === FILTER_METHODS.REMOTE) {
-            store.dispatch(doRemoteFilter(filter.filterMenuValues, pageIndex, pageSize, filterSource));
+            store.dispatch(
+                doRemoteFilter({
+                    filterParams: filter.filterMenuValues,
+                    pageIndex,
+                    pageSize,
+                    dataSource: filterSource,
+                    stateKey
+                })
+            );
         }
 
     }

--- a/src/components/plugins/filtercontainer/menu/Input.jsx
+++ b/src/components/plugins/filtercontainer/menu/Input.jsx
@@ -8,7 +8,9 @@ import {
     setFilterMenuValues
 } from './../../../../actions/plugins/filter/FilterActions';
 
-export const Input = ({ filter, field, store }) => {
+export const Input = ({ filter, field, stateKey, store }) => {
+
+    console.log(stateKey)
 
     const value = filter
         && filter.filterMenuValues
@@ -27,7 +29,7 @@ export const Input = ({ filter, field, store }) => {
         placeholder: field.placeholder,
         name: field.name,
         className: prefix(CLASS_NAMES.FILTER_CONTAINER.MENU.FIELD.INPUT),
-        onChange: handleDynamicInputChange.bind(this, filter, store),
+        onChange: handleDynamicInputChange.bind(this, filter, stateKey, store),
         value
     };
 
@@ -57,7 +59,7 @@ Input.defaultProps = {
 
 };
 
-export const handleDynamicInputChange = (filter, store, reactEvent) => {
+export const handleDynamicInputChange = (filter, stateKey, store, reactEvent) => {
 
     const name = reactEvent.target.name;
     const value = reactEvent.target.value;
@@ -70,5 +72,5 @@ export const handleDynamicInputChange = (filter, store, reactEvent) => {
         return false;
     }
 
-    store.dispatch(setFilterMenuValues(newFilterValues));
+    store.dispatch(setFilterMenuValues({ filter: newFilterValues, stateKey }));
 };

--- a/src/components/plugins/filtercontainer/toolbar/ClearButton.jsx
+++ b/src/components/plugins/filtercontainer/toolbar/ClearButton.jsx
@@ -8,7 +8,7 @@ import { setFilter,
     clearFilterLocal
 } from './../../../../actions/plugins/filter/FilterActions';
 
-export const ClearButton = ({ dataUri, method, store }) => {
+export const ClearButton = ({ dataUri, method, stateKey, store }) => {
 
     const buttonProps = {
         className: prefix(CLASS_NAMES.FILTER_CONTAINER.CLEAR_BUTTON),
@@ -21,17 +21,17 @@ export const ClearButton = ({ dataUri, method, store }) => {
 
 };
 
-export const clearFilter = (dataSource, method, store) => {
+export const clearFilter = (dataSource, method, stateKey, store) => {
 
     if (method === FILTER_METHODS.LOCAL) {
-        store.dispatch(clearFilterLocal());
+        store.dispatch(clearFilterLocal({ stateKey }));
     }
 
     else if (method === FILTER_METHODS.REMOTE) {
-        store.dispatch(clearFilterRemote(dataSource));
+        store.dispatch(clearFilterRemote({ dataSource, stateKey }));
     }
 
-    store.dispatch(setFilter(''));
+    store.dispatch(setFilter({ filter: '', stateKey }));
 };
 
 ClearButton.propTypes = {};

--- a/src/components/plugins/filtercontainer/toolbar/FilterButton.jsx
+++ b/src/components/plugins/filtercontainer/toolbar/FilterButton.jsx
@@ -5,12 +5,12 @@ import { CLASS_NAMES } from './../../../../constants/GridConstants';
 
 import { showFilterMenu } from './../../../../actions/plugins/filter/FilterActions';
 
-export const FilterButton = ({ filter, filterMenuShown, store }) => {
+export const FilterButton = ({ filter, filterMenuShown, store, stateKey }) => {
 
     const buttonProps = {
         className: prefix(CLASS_NAMES.FILTER_CONTAINER.MENU_BUTTON,
             filterMenuShown ? CLASS_NAMES.ACTIVE_CLASS : ''),
-        onClick: handleFilterMenuButtonClick.bind(this, filter, store)
+        onClick: handleFilterMenuButtonClick.bind(this, filter, stateKey, store)
     };
 
     return (
@@ -19,9 +19,9 @@ export const FilterButton = ({ filter, filterMenuShown, store }) => {
 
 };
 
-export const handleFilterMenuButtonClick = (filter, store) => {
+export const handleFilterMenuButtonClick = (filter, stateKey, store) => {
     const shown = filter ? filter.filterMenuShown : false;
-    store.dispatch(showFilterMenu(shown));
+    store.dispatch(showFilterMenu({ value: shown, stateKey}));
 };
 
 FilterButton.propTypes = {

--- a/src/components/plugins/gridactions/actioncolumn/Menu.jsx
+++ b/src/components/plugins/gridactions/actioncolumn/Menu.jsx
@@ -3,11 +3,11 @@ import { ConnectedMenu as MenuCmp } from './../../../core/menu/Menu.jsx';
 import { handleEditClick } from './../../../../util/handleEditClick';
 
 export const Menu = (
-    { actions, columns, type, store, editor, reducerKeys, rowId, rowData, rowIndex }
+    { actions, columns, type, store, editor, reducerKeys, rowId, rowData, rowIndex, stateKey }
 ) => {
 
     if (editor.config.enabled && type !== 'header') {
-        actions.menu.unshift(getEditAction(editor, store, rowId, rowData, rowIndex, columns));
+        actions.menu.unshift(getEditAction(editor, store, rowId, rowData, rowIndex, columns, stateKey));
     }
 
     const menuProps = {
@@ -18,6 +18,7 @@ export const Menu = (
             rowIndex
         },
         reducerKeys,
+        stateKey,
         store
     };
 
@@ -26,10 +27,10 @@ export const Menu = (
     );
 };
 
-export const getEditAction = (editor, store, rowId, rowData, rowIndex, columns) => {
+export const getEditAction = (editor, store, rowId, rowData, rowIndex, columns, stateKey) => {
     return {
         text: 'Edit',
-        EVENT_HANDLER: handleEditClick.bind(this, editor, store, rowId, rowData, rowIndex, columns),
+        EVENT_HANDLER: handleEditClick.bind(this, editor, store, rowId, rowData, rowIndex, columns, stateKey),
         key: 'grid-edit-action'
     };
 };

--- a/src/components/plugins/loader/LoadingBar.jsx
+++ b/src/components/plugins/loader/LoadingBar.jsx
@@ -30,7 +30,7 @@ LoadingBar.defaultProps = {};
 
 function mapStateToProps(state, props) {
     return {
-        isLoading: stateGetter(state, props, 'loader', 'loaderState')
+        isLoading: stateGetter(state, props, 'loader', props.stateKey)
     };
 }
 

--- a/src/components/plugins/pager/Toolbar.jsx
+++ b/src/components/plugins/pager/Toolbar.jsx
@@ -12,12 +12,18 @@ import { getCurrentRecords } from '../../../util/getCurrentRecords';
 export const PagerToolbar = ({
     BUTTON_TYPES, dataSource,
     pageSize, pager, pagerState, plugins,
-    recordType, store, toolbarRenderer}) => {
+    recordType, stateKey, store, toolbarRenderer}) => {
 
     const pagerDataSource = getPagingSource(plugins, dataSource);
 
     const customComponent = getCustomComponent(plugins, {
-        dataSource, pageSize, pager, ...{ gridData: pagerState }, plugins, recordType, store
+        dataSource,
+        pageSize,
+        pager,
+        ...{ gridData: pagerState },
+        plugins,
+        recordType,
+        store
     });
 
     if (customComponent) {
@@ -37,6 +43,7 @@ export const PagerToolbar = ({
                         pagerState,
                         pagerDataSource,
                         toolbarRenderer,
+                        stateKey,
                         store)
                     : <div />;
 
@@ -64,7 +71,9 @@ PagerToolbar.defaultProps = {
         NEXT: 'NEXT',
         BACK: 'BACK'
     },
-    toolbarRenderer: (pageIndex, pageSize, total, currentRecords, recordType) => {
+    toolbarRenderer: (
+        pageIndex, pageSize, total, currentRecords, recordType
+    ) => {
         if (!currentRecords) {
             return `No ${recordType} Available`;
         }
@@ -83,15 +92,18 @@ export const getCustomComponent = (plugins, props) => {
         : false;
 };
 
-export const getCurrentRecordTotal = (pagerState, pageSize, pageIndex, plugins) => {
+export const getCurrentRecordTotal = (
+    pagerState, pageSize, pageIndex, plugins
+) => {
 
-    if (plugins.PAGER.pagingType === 'remote' && pagerState && pagerState.currentRecords) {
+    if (plugins.PAGER.pagingType === 'remote'
+        && pagerState
+        && pagerState.currentRecords) {
         return pagerState.currentRecords.length;
     }
 
     else if (plugins.PAGER.pagingType === 'local') {
         const records = getCurrentRecords(pagerState, pageIndex, pageSize);
-
         return records ? records.length : 0;
     }
 
@@ -121,6 +133,7 @@ export const getPager = (dataSource, pageSize,
                         pagerState,
                         pagerDataSource,
                         toolbarRenderer,
+                        stateKey,
                         store) => {
 
     const pageIndex = pager && pager.pageIndex || 0;
@@ -129,7 +142,9 @@ export const getPager = (dataSource, pageSize,
         className: prefix(CLASS_NAMES.PAGERTOOLBAR)
     };
 
-    const currentRecords = getCurrentRecordTotal(pagerState, pageSize, pageIndex, plugins, dataSource);
+    const currentRecords = getCurrentRecordTotal(
+        pagerState, pageSize, pageIndex, plugins, dataSource
+    );
 
     const total = getTotal(pagerState, plugins.PAGER);
 
@@ -153,7 +168,8 @@ export const getPager = (dataSource, pageSize,
                     currentRecords,
                     total,
                     dataSource,
-                    store}
+                    stateKey,
+                    store }
                     }
                 />
                 <Button { ...{
@@ -165,6 +181,7 @@ export const getPager = (dataSource, pageSize,
                     currentRecords,
                     total,
                     dataSource,
+                    stateKey,
                     store }
                     }
                 />
@@ -187,9 +204,9 @@ export const getPagingSource = (plugins, dataSource) => {
 function mapStateToProps(state, props) {
 
     return {
-        pager: stateGetter(state, props, 'pager', 'pagerState'),
-        pagerState: stateGetter(state, props, 'dataSource', 'gridData'),
-        gridState: stateGetter(state, props, 'grid', 'gridState')
+        pager: stateGetter(state, props, 'pager', props.stateKey),
+        pagerState: stateGetter(state, props, 'dataSource', props.stateKey),
+        gridState: stateGetter(state, props, 'grid', props.stateKey)
     };
 }
 

--- a/src/components/plugins/pager/toolbar/Button.jsx
+++ b/src/components/plugins/pager/toolbar/Button.jsx
@@ -9,11 +9,11 @@ import {
 
 export const Button = ({
         BUTTON_TYPES, type, pageIndex, pageSize, plugins,
-        currentRecords, total, dataSource, backButtonText, nextButtonText, store
+        currentRecords, total, dataSource, backButtonText, nextButtonText, stateKey, store
     }) => {
 
     const buttonProps = {
-        onClick: handleButtonClick.bind(this, type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, store),
+        onClick: handleButtonClick.bind(this, type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, store),
         children: type === BUTTON_TYPES.NEXT ? nextButtonText : backButtonText,
         disabled: isButtonDisabled(type, pageIndex, pageSize, currentRecords, total, BUTTON_TYPES),
         className: prefix(CLASS_NAMES.BUTTONS.PAGER, type.toLowerCase())
@@ -24,16 +24,20 @@ export const Button = ({
     );
 };
 
-export const handleButtonClick = (type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, store) => {
+export const handleButtonClick = (type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, store) => {
 
     const PAGER = plugins.PAGER;
 
     if (PAGER.pagingType === 'local') {
-        store.dispatch(setPage(pageIndex, type, BUTTON_TYPES));
+        store.dispatch(
+            setPage({ index: pageIndex, type, BUTTON_TYPES, stateKey })
+        );
     }
 
     else if (PAGER.pagingType === 'remote' && dataSource) {
-        store.dispatch(setPageAsync(pageIndex, pageSize, type, BUTTON_TYPES, dataSource));
+        store.dispatch(
+            setPageAsync({index: pageIndex, pageSize, type, BUTTON_TYPES, dataSource, stateKey})
+        );
     }
 
     else {

--- a/src/components/plugins/selection/CheckBox.jsx
+++ b/src/components/plugins/selection/CheckBox.jsx
@@ -5,7 +5,7 @@ import { stateGetter } from '../../../util/stateGetter';
 import { CLASS_NAMES } from '../../../constants/GridConstants';
 import { selectAll, deselectAll } from '../../../actions/plugins/selection/ModelActions';
 
-export const CheckBox = ({dataSource, rowId, selectedRows, store, type}) => {
+export const CheckBox = ({dataSource, rowId, selectedRows, store, stateKey, type}) => {
 
     const checkBoxContainerProps = {
         className: prefix(CLASS_NAMES.SELECTION_MODEL.CHECKBOX_CONTAINER)
@@ -15,7 +15,7 @@ export const CheckBox = ({dataSource, rowId, selectedRows, store, type}) => {
         className: prefix(CLASS_NAMES.SELECTION_MODEL.CHECKBOX),
         checked: selectedRows ? selectedRows[rowId] : false,
         type: 'checkbox',
-        onChange: handleChange.bind(this, dataSource, store, type)
+        onChange: handleChange.bind(this, dataSource, store, type, stateKey)
     };
 
     return type === 'header'
@@ -23,20 +23,21 @@ export const CheckBox = ({dataSource, rowId, selectedRows, store, type}) => {
         : getColumn(checkBoxContainerProps, checkBoxProps);
 };
 
-export const handleChange = (dataSource, store, type, reactEvent) => {
+export const handleChange = (dataSource, store, type, stateKey, reactEvent) => {
     const target = reactEvent.target;
 
     if (type === 'header') {
         if (target.checked) {
-            store.dispatch(selectAll(dataSource));
+            store.dispatch(selectAll({ stateKey, data: dataSource }));
         }
         else {
-            store.dispatch(deselectAll());
+            store.dispatch(deselectAll({ stateKey }));
         }
     }
 };
 
 export const getHeader = (checkBoxContainerProps, checkBoxProps) => {
+
     return (
         <th { ...checkBoxContainerProps } >
             <input type="checkbox" { ...checkBoxProps } />
@@ -67,9 +68,9 @@ CheckBox.defaultProps = {};
 function mapStateToProps(state, props) {
 
     return {
-        pager: stateGetter(state, props, 'pager', 'pagerState'),
-        dataSource: stateGetter(state, props, 'dataSource', 'gridData'),
-        selectedRows: stateGetter(state, props, 'selection', 'selectedRows')
+        pager: stateGetter(state, props, 'pager', props.stateKey),
+        dataSource: stateGetter(state, props, 'dataSource', props.stateKey),
+        selectedRows: stateGetter(state, props, 'selection', props.stateKey)
     };
 }
 

--- a/src/components/plugins/selection/Model.js
+++ b/src/components/plugins/selection/Model.js
@@ -5,7 +5,7 @@ import { ConnectedCheckBox as CheckBox } from './CheckBox.jsx';
 
 export default class Model {
 
-    init(plugins, store, events) {
+    init(plugins, stateKey, store, events) {
 
         const eventTypes = {
             singleclick: 'singleclick',
@@ -37,6 +37,7 @@ export default class Model {
         this.eventTypes = eventTypes;
         this.modes = modes;
         this.store = config.store;
+        this.stateKey = stateKey;
         this.events = events;
     }
 
@@ -50,7 +51,14 @@ export default class Model {
             this.events.HANDLE_BEFORE_BULKACTION_SHOW(selectionEvent);
         }
 
-        this.store.dispatch(setSelection(selectionEvent.id, this.defaults, this.modes));
+        this.store.dispatch(
+            setSelection({
+                id: selectionEvent.id,
+                defaults: this.defaults,
+                modes: this.modes,
+                stateKey: this.stateKey
+            })
+        );
 
         if (this.events.HANDLE_AFTER_SELECTION) {
             this.events.HANDLE_AFTER_SELECTION(selectionEvent);
@@ -62,15 +70,16 @@ export default class Model {
 
     }
 
-    updateCells(cells, rowId, type, reducerKeys) {
+    updateCells(cells, rowId, type, reducerKeys, stateKey) {
 
         const cellsUpdate = cells;
-
+        
         const checkBoxProps = {
             key: keyFromObject(rowId, ['checkbox-']),
             rowId,
             type,
             reducerKeys,
+            stateKey,
             store: this.store
         };
 

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -18,6 +18,7 @@ export const SET_SORT_DIRECTION = 'SET_SORT_DIRECTION';
 export const SET_LOADING_STATE = 'SET_LOADING_STATE';
 
 export const DISMISS_ERROR = 'DISMISS_ERROR';
+export const ERROR_OCCURRED = 'ERROR_OCCURRED';
 
 export const SHOW_MENU = 'SHOW_MENU';
 export const HIDE_MENU = 'HIDE_MENU';

--- a/src/reducers/components/datasource.js
+++ b/src/reducers/components/datasource.js
@@ -9,98 +9,100 @@ import { SET_DATA,
     SORT_DATA
 } from '../../constants/ActionTypes';
 
-const initialState = fromJS({
-    gridData: fromJS.Map
-});
+const initialState = fromJS({});
 
 export default function dataSource(state = initialState, action) {
     switch (action.type) {
 
     case SET_DATA:
-        return state.set('gridData', Object.assign({}, state.get('gridData'),
-            {
-                data: action.data,
-                proxy: action.data,
-                total: action.total || action.data.length,
-                currentRecords: action.currentRecords || action.data
-            }
-        ));
+        return state.setIn([action.stateKey], {
+            data: action.data,
+            proxy: action.data,
+            total: action.total || action.data.length,
+            currentRecords: action.currentRecords || action.data
+        });
 
     case DISMISS_EDITOR:
-        if (state.get('gridData')) {
-            return state.set('gridData', Object.assign({}, state.get('gridData'),
-                {
-                    data: state.get('gridData').proxy,
-                    currentRecords: state.get('gridData').proxy
-                }
-            ));
+        if (state.get(action.stateKey)) {
+            return state.updateIn([action.stateKey], (values) => ({
+                data: values.proxy,
+                proxy: values.proxy,
+                currentRecords: values.proxy,
+                total: values.total,
+                isEditing: false
+            }));
         }
 
         return state;
 
     case REMOVE_ROW:
-        const remainingRows = [...state.get('gridData').data];
+        const remainingRows = [...state.get(action.stateKey).data];
         remainingRows.splice(action.rowIndex || 0, 1);
 
-        return state.set('gridData', Object.assign({}, state.get('gridData'),
-            {
-                data: remainingRows,
-                proxy: remainingRows
-            }
-        ));
+        return state.updateIn([action.stateKey], (values) => ({
+            data: remainingRows,
+            proxy: remainingRows,
+            total: values.total,
+            currentRecords: values.currentRecords
+        }));
 
     case ADD_NEW_ROW:
-        const existingData = state.get('gridData');
 
-        const rowModel = gridData
+        const existingData = state.get(action.stateKey);
+
+        if (existingData && existingData.isEditing) {
+            return state;
+        }
+
+        const rowModel = existingData
             && existingData.data
             && existingData.data.length > 0
             && existingData.data[0]
             ? existingData.data[0]
             : {};
 
-        Object.keys(rowModel).forEach((k) => rowModel[k] = '');
+        const newRow = {};
 
-        const data = [rowModel, ...state.get('gridData').data];
+        Object.keys(rowModel).forEach((k) => newRow[k] = '');
 
-        return state.set('gridData', Object.assign({}, state.get('gridData'),
-            {
-                data: data,
-                proxy: state.get('gridData').proxy
-            }
-        ));
+        return state.updateIn([action.stateKey], (values) => ({
+            ...values,
+            data: [newRow, ...values.data],
+            proxy: values.data,
+            isEditing: true
+        }));
 
     case SAVE_ROW:
-        const gridData = state.get('gridData').data;
+        const gridData = state.get(action.stateKey).data;
         gridData[action.rowIndex] = action.values;
 
-        return state.set('gridData', Object.assign({}, state.get('gridData'),
-            {
-                data: gridData,
-                proxy: gridData
-            }
-        ));
+        return state.updateIn([action.stateKey], (values) => ({
+            data: gridData,
+            proxy: gridData,
+            total: values.total,
+            currentRecords: gridData
+        }));
 
     case SORT_DATA:
-        return state.set('gridData', Object.assign({}, state.get('gridData'),
-            {
-                data: action.data
-            }
-        ));
+        return state.mergeIn([action.stateKey], {
+            data: action.data
+        });
 
     case CLEAR_FILTER_LOCAL:
-        return state.set('gridData', Object.assign({}, state.get('gridData'),
-            {
-                data: state.get('gridData').proxy
-            }
-        ));
+
+        const existing = state.get(action.stateKey);
+        const recs = existing.proxy || existing.currentRecords;
+
+        return state.mergeIn([action.stateKey], {
+            data: recs,
+            proxy: recs
+        });
 
     case FILTER_DATA:
-        return state.set('gridData', Object.assign({}, state.get('gridData'),
-            {
-                data: action.data
-            }
-        ));
+        return state.mergeIn([action.stateKey], {
+            data: action.data
+        });
+
     default:
 
         return state;

--- a/src/reducers/components/grid.js
+++ b/src/reducers/components/grid.js
@@ -1,33 +1,41 @@
 import { fromJS } from 'immutable';
 
-import { SET_COLUMNS, RESIZE_COLUMNS, SET_SORT_DIRECTION } from '../../constants/ActionTypes';
+import {
+    SET_COLUMNS,
+    RESIZE_COLUMNS,
+    SET_SORT_DIRECTION
+} from '../../constants/ActionTypes';
 
-const initialState = fromJS({
-    gridState: fromJS.Map
-});
+const initialState = fromJS({});
 
 export default function gridState(state = initialState, action) {
 
     switch (action.type) {
 
     case SET_COLUMNS:
-        return state.set('gridState', {
+        return state.setIn([action.stateKey], {
             columns: action.columns
         });
 
     case SET_SORT_DIRECTION:
-
-        return state.set('gridState', Object.assign({}, state.get('gridState'),
-            {
-                columns: action.columns
-            }
-        ));
-
-    case RESIZE_COLUMNS:
-
-        return state.set('gridState', {
+        return state.setIn([action.stateKey], {
             columns: action.columns
         });
+
+    case RESIZE_COLUMNS:
+        return state.set(action.stateKey,
+            Object.assign({}, state.get('gridState'), {
+                columns: action.columns
+            })
+        );
+
+        // NOT USING IMMUTABLE
+        // THIS ACTION IS FIRED AT SUCH A HIGH RATE, NEED TO OPTIMIZE
+        // BY NOT USING IMMUTABLE STATE GETTER
+
+        // return state.setIn([action.stateKey], {
+        //     columns: action.columns
+        // });
 
     default:
 

--- a/src/reducers/components/plugins/bulkaction.js
+++ b/src/reducers/components/plugins/bulkaction.js
@@ -4,18 +4,14 @@ import {
     REMOVE_TOOLBAR
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({
-    bulkActionState: {
-        isRemoved: true
-    }
-});
+const initialState = fromJS({});
 
 export default function bulkaction(state = initialState, action) {
 
     switch (action.type) {
 
     case REMOVE_TOOLBAR:
-        return state.set('bulkActionState', {
+        return state.setIn([action.stateKey], {
             isRemoved: action.value
         });
 

--- a/src/reducers/components/plugins/editor.js
+++ b/src/reducers/components/plugins/editor.js
@@ -43,7 +43,7 @@ export default function editor(state = initialState, action) {
 
         const isValid = isRowValid(action.columns, action.values);
 
-        return state.set('editorState', {
+        return state.setIn([action.stateKey], {
             row: {
                 key: action.rowId,
                 values: action.values,
@@ -55,8 +55,8 @@ export default function editor(state = initialState, action) {
         });
 
     case ROW_VALUE_CHANGE:
-        const { columns, value } = action;
-        const previous = state.get('editorState');
+        const { columns, value, stateKey } = action;
+        const previous = state.get(stateKey);
 
         const rowValues = Object.assign({}, previous.row.values, {
             [action.columnName]: value
@@ -71,7 +71,7 @@ export default function editor(state = initialState, action) {
 
         const valid = isRowValid(columns, rowValues);
 
-        return state.set('editorState', Object.assign({}, state.get('editorState'), {
+        return state.setIn([action.stateKey], {
             row: {
                 key: previous.row.key,
                 values: rowValues,
@@ -81,12 +81,12 @@ export default function editor(state = initialState, action) {
                 isCreate: previous.row.isCreate || false,
                 valid
             }
-        }));
+        });
 
     case REMOVE_ROW:
     case DISMISS_EDITOR:
     case CANCEL_ROW:
-        return state.set('editorState', {});
+        return state.setIn([action.stateKey], {});
 
     default:
         return state;

--- a/src/reducers/components/plugins/filter.js
+++ b/src/reducers/components/plugins/filter.js
@@ -15,23 +15,22 @@ export default function filter(state = initialState, action) {
     switch (action.type) {
 
     case SET_FILTER_VALUE:
-        return state.set('filterState', Object.assign({}, state.get('filterState'),
-            {
-                filterValue: action.value
-            }
-        ));
+        return state.mergeIn([action.stateKey], {
+            filterValue: action.value
+        });
 
     case SET_FILTER_MENU_VALUES:
-        return state.set('filterState', Object.assign({}, state.get('filterState'),
-            {
-                filterMenuValues: action.filter
-            }
-        ));
+        return state.mergeIn([action.stateKey], {
+            filterMenuValues: Object.assign(
+                state.get(action.stateKey).filterMenuValues || {}, action.filter
+            ),
+            filterMenuShown: true
+        });
 
     case SHOW_FILTER_MENU:
-        return state.set('filterState', Object.assign({}, state.get('filterState'),
-            action.metaData
-        ));
+        return state.setIn([action.stateKey], {
+            filterMenuShown: action.metaData.filterMenuShown
+        });
 
     default:
         return state;

--- a/src/reducers/components/plugins/loader.js
+++ b/src/reducers/components/plugins/loader.js
@@ -13,7 +13,7 @@ export default function loader(state = initialState, action) {
     switch (action.type) {
 
     case SET_LOADING_STATE:
-        return state.set('loaderState', action.state);
+        return state.setIn([action.stateKey], action.state);
 
     default:
         return state;

--- a/src/reducers/components/plugins/menu.js
+++ b/src/reducers/components/plugins/menu.js
@@ -5,29 +5,27 @@ import {
     HIDE_MENU
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({
-    menuState: fromJS.Map
-});
+const initialState = fromJS({});
 
 export default function menu(state = initialState, action) {
 
     switch (action.type) {
 
     case SHOW_MENU:
-        return state.set('menuState', {
+        return state.setIn([action.stateKey], {
             [action.id]: true
         });
 
     case HIDE_MENU:
 
         if (action.id) {
-            return state.set('menuState', {
+            return state.setIn([action.stateKey], {
                 [action.id]: false
             });
         }
 
         else {
-            return state.set('menuState', {});
+            return state.setIn([action.stateKey], {});
         }
 
     default:

--- a/src/reducers/components/plugins/pager.js
+++ b/src/reducers/components/plugins/pager.js
@@ -14,18 +14,14 @@ export default function pager(state = initialState, action) {
     switch (action.type) {
 
     case PAGE_LOCAL:
-        return state.set('pagerState', Object.assign({}, state.get('pagerState'),
-            {
-                pageIndex: action.pageIndex
-            }
-        ));
+        return state.setIn([action.stateKey], {
+            pageIndex: action.pageIndex
+        });
 
     case PAGE_REMOTE:
-        return state.set('pagerState', Object.assign({}, state.get('pagerState'),
-            {
-                pageIndex: action.pageIndex
-            }
-        ));
+        return state.setIn([action.stateKey], {
+            pageIndex: action.pageIndex
+        });
 
     default:
         return state;

--- a/src/reducers/components/plugins/selection.js
+++ b/src/reducers/components/plugins/selection.js
@@ -6,41 +6,35 @@ import {
     DESELECT_ALL
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({
-    selectedRows: fromJS.Map
-});
+const initialState = fromJS({});
 
 export default function selection(state = initialState, action) {
 
     switch (action.type) {
 
     case SELECT_ALL:
-
-        return state.set('selectedRows', action.selection);
+        return state.setIn([action.stateKey], action.selection);
 
     case DESELECT_ALL:
 
-        return state.set('selectedRows', {});
+        return state.setIn([action.stateKey], {});
 
     case SET_SELECTION:
 
-        const currentValue = state.get('selectedRows') ? state.get('selectedRows')[action.id] : false;
+        const currentValue = state.get(action.stateKey)
+            ? state.get(action.stateKey)[action.id]
+            : false;
 
-        if (action.clearSelections) {
-            return state.set('selectedRows',
-                {
-                    [action.id]: currentValue && action.allowDeselect ? false : true
-                }
-            );
+        if (action.clearSelections || !state.get(action.stateKey)) {
+            return state.setIn([action.stateKey], {
+                [action.id]: currentValue && action.allowDeselect ? false : true
+            });
         }
 
-        else {
-            return state.set('selectedRows', Object.assign({}, state.get('selectedRows'),
-                {
-                    [action.id]: currentValue && action.allowDeselect ? false : true
-                }
-            ));
-        }
+        // enable multiselect
+        return state.setIn([action.stateKey], {
+            [action.id]: currentValue && action.allowDeselect ? false : true
+        });
 
     default:
         return state;

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -4,7 +4,7 @@ import logger from 'redux-diff-logger';
 import thunk from 'redux-thunk';
 
 export default function configureStore(initialState) {
-    const createStoreWithMiddleware = applyMiddleware(thunk)(createStore);
+    const createStoreWithMiddleware = applyMiddleware(thunk, logger)(createStore);
     const store = createStoreWithMiddleware(rootReducer, initialState);
 
     if (module.hot) {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -2,4 +2,6 @@ import configureStore from './configureStore';
 
 const store = configureStore();
 
+export { store as Store };
+
 export default store;

--- a/src/util/handleEditClick.js
+++ b/src/util/handleEditClick.js
@@ -1,12 +1,16 @@
 import { editRow } from './../actions/plugins/editor/EditorActions';
 
-export const handleEditClick = (editor, store, rowId, rowData, rowIndex, columns, data) => {
+export const handleEditClick = (editor, store, rowId, rowData, rowIndex, columns, stateKey, data) => {
     const row = closestRow(data.reactEvent.target);
     const offset = 7;
     const top = row.offsetTop + row.clientHeight + offset;
 
     if (editor.config.type === editor.editModes.inline) {
-        store.dispatch(editRow(rowId, top, rowData, rowIndex, columns));
+        store.dispatch(
+            editRow({
+                rowId, top, rowData, rowIndex, columns, stateKey
+            })
+        );
     }
 };
 

--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -1,5 +1,5 @@
 export function stateGetter(state, props, key, entry) {
-    
+
     if (props
         && props.reducerKeys
         && Object.keys(props.reducerKeys).length > 0
@@ -15,6 +15,17 @@ export function stateGetter(state, props, key, entry) {
             : null;
     }
 
+    const firstTry = state
+        && state[key]
+        && state[key].get
+        && state[key].get(entry)
+        ? state[key].get(entry)
+        : null;
+
+    if (firstTry) {
+        return firstTry;
+    }
+
     const keys = Object.keys(state);
     const normalizedKeys = keys
         .map((s) => s.toLowerCase());
@@ -27,7 +38,7 @@ export function stateGetter(state, props, key, entry) {
             && state[keys[keyIndex]].get
             && state[keys[keyIndex]].get(entry)
             ? state[keys[keyIndex]].get(entry)
-            : null; 
+            : null;
     }
 
     return null;

--- a/test/components/Grid.test.js 
+++ b/test/components/Grid.test.js 
@@ -1,26 +1,152 @@
+/* eslint-enable describe it */
 import expect from 'expect';
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Grid } from '../../src/components/Grid.jsx';
-import { mockStore } from '../testUtils/index';
+import { mount } from 'enzyme';
+import { ConnectedGrid } from './../../src/components/Grid.jsx';
+import { Store as GridStore } from './../../src/store/store';
+import { mockStore } from './../testUtils/index';
+
 import { gridColumns,
     localGridData,
-    gridActions
+    gridActions,
+    stateKey
 } from '../testUtils/data';
 
 const props = {
     data: localGridData,
     columns: gridColumns,
-    store: mockStore({}, ...gridActions)
+    stateKey,
+    store: mockStore({}, ...gridActions),
+    plugins: {}
 };
 
 props.store.subscribe = () => {};
 
-describe('A rendered Grid Component if columns, data, and a store are passed', () => {
+describe('A fully mounted simple grid', () => {
 
-    it('Should render with the correct className', () => {
-        const component = shallow(<Grid { ...props } />);
-        expect(component.props().className).toEqual('react-grid-container');
+    const simpleProps = {
+        ...props,
+        store: GridStore
+    };
+
+    const component = mount(<ConnectedGrid { ...simpleProps } />);
+
+    it('Should render with the correct number of rows', () => {
+        expect(
+            component.find('.react-grid-row').length
+        ).toEqual(2);
+    });
+
+    it('Should render 2 headers, only 1 visible', () => {
+        expect(
+            component.find('.react-grid-header').length
+        ).toEqual(2);
+
+        expect(
+            component.find('.react-grid-header.react-grid-header-hidden').length
+        ).toEqual(1);
+    });
+
+    it('Shouldn\'t render a pager', () => {
+        expect(
+            component.find('.react-grid-pager-toolbar').length
+        ).toEqual(0);
+    });
+
+    it('Shouldn\'t render 4 headers, 2 visible', () => {
+        expect(
+            component.find('.react-grid-header').find('th').length
+        ).toEqual(4);
+
+        expect(
+            component
+                .find('.react-grid-header.react-grid-header-hidden')
+                .find('th').length
+        ).toEqual(2);
+    });
+
+    it('Shouldn\'t render the bulk action plugin', () => {
+        expect(
+            component.find('.react-grid-bulkaction-container').length
+        ).toEqual(0);
+    });
+
+    it('Should render the correct cells', () => {
+        expect(
+            component.find('td').node.innerHTML
+        ).toContain('Michael Jordan');
+    });
+
+    it('Should render the correct number of cells', () => {
+        expect(
+            component.find('td').nodes.length
+        ).toEqual(4);
+    });
+
+});
+
+describe('A fully mounted grid with a custom pager', () => {
+
+    const customPagerProps = {
+        ...props,
+        store: GridStore,
+        plugins: {
+            PAGER: {
+                enabled: true,
+                pagerComponent: (
+                    <span className = { 'custom-pager' } >
+                        { 'Custom Pager' }
+                    </span>
+                    )
+            }
+        }
+    };
+
+    const component = mount(<ConnectedGrid { ...customPagerProps } />);
+
+    it('Should have a pager', () => {
+        expect(
+            component.find('.custom-pager').length
+        ).toEqual(1);
+    });
+
+});
+
+describe('A fully mounted grid with pager', () => {
+
+    const pagerProps = {
+        ...props,
+        store: GridStore,
+        plugins: {
+            PAGER: {
+                enabled: true,
+                pagingType: 'local'
+            }
+        }
+    };
+
+    const component = mount(<ConnectedGrid { ...pagerProps } />);
+
+    beforeEach((done) => {
+        component.update();
+
+        setTimeout(() => {
+            done();
+        }, 100);
+    });
+
+    it('Should have a pager', () => {
+        expect(
+            component.find('.react-grid-pager-toolbar').length
+        ).toEqual(1);
+    });
+
+    it('Should have the right pager message', () => {
+        expect(
+           component
+            .find('.react-grid-pager-toolbar').text()
+            .replace(/ +?|\n/g, '')
+        ).toContain('1through2of2RecordsDisplayed');
     });
 
 });

--- a/test/components/plugins/pager/toolbar/Button.test.js
+++ b/test/components/plugins/pager/toolbar/Button.test.js
@@ -9,6 +9,8 @@ import { localGridData } from './../../../../testUtils/data';
 
 const store = mockStore();
 
+const stateKey = 'stateKey';
+
 store.subscribe = () => {};
 
 const props = {
@@ -60,7 +62,9 @@ describe('handleButtonClick function with local paging', () => {
 
     it('The action should reflect the next page when clicked', () => {
         expect(
-            ButtonUtils.handleButtonClick(type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, localPagedStore)
+            ButtonUtils.handleButtonClick(
+                type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, localPagedStore
+            )
         ).toEqual(undefined);
     });
 });
@@ -83,7 +87,9 @@ describe('handleButtonClick function with remote paging', () => {
 
     it('The action should reflect a loading state when clicking next with a remote pager', () => {
         expect(
-            ButtonUtils.handleButtonClick(type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, localPagedStore)
+            ButtonUtils.handleButtonClick(
+                type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, localPagedStore
+            )
         ).toEqual(undefined);
     });
 });
@@ -107,7 +113,7 @@ describe('handleButtonClick function without a pagingType specified', () => {
     it('Should not dispatch an action', () => {
         expect(
             ButtonUtils.handleButtonClick(
-                type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, uncalledStore
+                type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, uncalledStore
             )
         ).toEqual(undefined);
     });

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,8 +1,8 @@
 const loaders = require('../webpack/loaders');
 const path = require('path');
 const BROWSERS = process.argv && process.argv.indexOf('--browser') !== -1
-    ? ['PhantomJS', 'Chrome']
-    : ['PhantomJS'];
+    ? ['jsdom', 'Chrome']
+    : ['jsdom'];
 
 module.exports = function exports(config) {
     config.set({
@@ -18,10 +18,9 @@ module.exports = function exports(config) {
             'karma-es6-shim',
             'karma-webpack',
             'karma-babel-preprocessor',
-            'karma-phantomjs-launcher',
+            'karma-jsdom-launcher',
             'karma-sourcemap-loader',
             'karma-sinon-chai',
-            'phantomjs-prebuilt'
         ],
 
         preprocessors: {

--- a/test/testUtils/data.js
+++ b/test/testUtils/data.js
@@ -7,14 +7,18 @@ import { keyGenerator } from '../../src/util/keyGenerator';
 
 // grid test data
 
+export const stateKey = 'test-stateKey';
+
 export const gridColumns = [
     {
         name: 'Player',
-        id: keyGenerator('Player', 'grid-column')
+        id: keyGenerator('Player', 'grid-column'),
+        dataIndex: 'name'
     },
     {
         name: 'Position',
-        id: keyGenerator('Player', 'grid-column')
+        id: keyGenerator('Player', 'grid-column'),
+        dataIndex: 'position'
     }
 ];
 

--- a/test/util/prefix.test.js
+++ b/test/util/prefix.test.js
@@ -6,7 +6,11 @@ describe('prefix utility function', () => {
     it('Should work with a destructured array of classes', () => {
         const classes = ['react', 'redux', 'grid', 'test'];
 
-        expect(prefix(...classes)).toEqual('react-grid-react react-grid-redux react-grid-grid react-grid-test');
+        expect(
+            prefix(...classes)
+        ).toEqual(
+            'react-grid-react react-grid-redux react-grid-grid react-grid-test'
+        );
     });
 
     it('Should work with a single class', () => {

--- a/test/util/stateGetter.test.js
+++ b/test/util/stateGetter.test.js
@@ -11,21 +11,32 @@ describe('State Getter Function', () => {
     it('Should return state if its registered', () => {
         const state = { filterState: { get: getState } };
         const props = {};
-        expect(stateGetter(state, props, 'filterState', 'someProp')).toBeTruthy();
+        expect(
+            stateGetter(state, props, 'filterState', 'someProp')
+        ).toBeTruthy();
     });
 
     it('Should return state even if the casing is off', () => {
         const state = { filterState: { get: getState } };
         const props = {};
-        expect(stateGetter(state, props, 'filterstate', 'someProp')).toBeTruthy();
-        expect(stateGetter(state, props, 'FILTERSTATE', 'someProp')).toBeTruthy();
-        expect(stateGetter(state, props, 'FilterState', 'someProp')).toBeTruthy();
+
+        expect(stateGetter(
+            state, props, 'filterstate', 'someProp')
+        ).toBeTruthy();
+        expect(stateGetter(
+            state, props, 'FILTERSTATE', 'someProp')
+        ).toBeTruthy();
+        expect(stateGetter(
+            state, props, 'FilterState', 'someProp')
+        ).toBeTruthy();
     });
 
     it('Should return null if it\'s not registered', () => {
         const state = { filterState: { get: getState } };
         const props = {};
-        expect(stateGetter(state, props, 'unknownState', 'someProp')).toEqual(null);
+        expect(
+            stateGetter(state, props, 'unknownState', 'someProp')
+        ).toEqual(null);
     });
 
     it('Should return state when a dynamic key is used if it\'s registerd', () => {
@@ -35,7 +46,9 @@ describe('State Getter Function', () => {
                 filterState: 'someFilterState'
             }
         };
-        expect(stateGetter(state, props, 'filterState', 'someProp')).toBeTruthy();
+        expect(
+            stateGetter(state, props, 'filterState', 'someProp')
+        ).toBeTruthy();
     });
 
     it('Should return null when a dynamic key is used if it`\s not registered', () => {
@@ -45,13 +58,17 @@ describe('State Getter Function', () => {
                 filterState: 'someFilterState'
             }
         };
-        expect(stateGetter(state, props, 'filterState', 'someProp')).toEqual(null);
+        expect(
+            stateGetter(state, props, 'filterState', 'someProp')
+        ).toEqual(null);
     });
 
     it('Should return null when no keys and no state are provided', () => {
         const state = {};
         const props = {};
-        expect(stateGetter(state, props, 'filterState', 'someProp')).toEqual(null);
+        expect(
+            stateGetter(state, props, 'filterState', 'someProp')
+        ).toEqual(null);
     });
 
 


### PR DESCRIPTION
### Adding stateKey as required parameter

#### Purpose
Previous to this merge request, there could only be a single grid rendered at a time. If a second grid was rendered, it would clobber the existing grid's state (all associated grid data). 

#### Solution
In order to maintain `n` number of grids, a `stateKey` is used to keep grid data separate in the grid `reducers`. The `stateKey` is now a required parameter for all grid. **This is a breaking change** for previous versions of grid. However, users will see in the console a friendly error message: `please provide a unique stateKey`. Once a `stateKey` is provided, everything will work as normal.

