### PR TITLE
adding suppoer for dataIndex as a string array

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -209,7 +209,25 @@ To add a plugin, simply create a file, and add the JSX to `src/grid.jsx`. The pl
 Column Defaults:
 
 1. `name`: `string`, title of column 
-2. `dataIndex`: `string`, the key accessor for the column value (required parameter)
+2. `dataIndex`: `string | arrayOf(string)`, the key accessor for the column value (required parameter). if data is provided as a complex object, deeply nested data can be accessed by providing an array of keys
+
+Example: 
+
+	const data = {
+		outer: {
+			middle: {
+				inner: 'rowValue'
+			}
+		}	
+	};
+
+You can access this data by providing the column the following dataIndex:
+
+	const column = {
+		name: 'Value',
+		dataIndex: ['outer', 'middle', 'inner']
+	};
+
 3. `editor`: `jsx element`, when an editor is used, this element will be rendered in place of the edited cell
 4. `width`: `string | int`, width of column (if none is provided, a default width will be applied)
 5. `className`: `string`, additional class names to apply to columns header output

--- a/src/components/core/ColumnManager.js
+++ b/src/components/core/ColumnManager.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ActionColumn from '../plugins/gridactions/ActionColumn.jsx';
 import { SORT_METHODS, DEFAULT_PAGE_SIZE } from '../../constants/GridConstants';
 import { keyFromObject } from '../../util/keyGenerator';
-import { camelize } from '../../util/camelize';
+import { nameFromDataIndex } from '../../util/getData';
 import { doLocalSort, doRemoteSort } from '../../actions/GridActions';
 import sorter from '../../util/sorter';
 
@@ -57,7 +57,7 @@ export default class ColumnManager {
         method, column, direction, dataSource, pagerState, stateKey
     }) {
 
-        const propName = column.dataIndex || camelize(column.name);
+        const propName = nameFromDataIndex(column);
 
         const sortParams = {
             sort: {

--- a/src/components/layout/Row.jsx
+++ b/src/components/layout/Row.jsx
@@ -6,6 +6,7 @@ import { PlaceHolder } from './row/PlaceHolder.jsx';
 
 import { keyGenerator } from '../../util/keyGenerator';
 import { prefix } from '../../util/prefix';
+import { getData } from '../../util/getData';
 import { getCurrentRecords } from '../../util/getCurrentRecords';
 import { CLASS_NAMES } from '../../constants/GridConstants';
 
@@ -93,11 +94,7 @@ export const addEmptyInsert = (cells, visibleColumns, plugins) => {
 
 export const getCellData = (columns, row, key, index, store) => {
 
-    const valueAtDataIndex = row
-        && columns[index]
-        && columns[index].dataIndex
-        ? row[columns[index].dataIndex]
-        : null;
+    const valueAtDataIndex = getData(row, columns, index);
 
     // if a render has been provided, default to this
     if (row
@@ -121,12 +118,16 @@ export const getCellData = (columns, row, key, index, store) => {
     }
 
     // else no data index found
-    console.warn('No dataIndex found for this column ', columns);
 };
 
 export const addEmptyCells = (rowData, columns) => {
 
     columns.forEach((col) => {
+
+        // const data = nameFromDataIndex(col);
+        // come back to this
+        // how we retrieve and store data, especially editable
+        // may need to be updated based on array dataIndex
 
         if (rowData && !rowData.hasOwnProperty(col.dataIndex)) {
             rowData[col.dataIndex] = '';

--- a/src/components/layout/cell/Editor.jsx
+++ b/src/components/layout/cell/Editor.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import { Input } from './Input.jsx';
 import { CLASS_NAMES } from './../../../constants/GridConstants';
 import { prefix } from './../../../util/prefix';
+import { nameFromDataIndex } from './../../../util/getData';
 
 const wrapperCls = prefix(CLASS_NAMES.EDITOR.INLINE.INPUT_WRAPPER);
 
@@ -11,8 +12,7 @@ export const Editor = ({
 
     let colName = columns
         && columns[index]
-        && columns[index].dataIndex
-        ? columns[index].dataIndex
+        ? nameFromDataIndex(columns[index])
         : '';
 
     if (!colName) {

--- a/src/components/layout/cell/Input.jsx
+++ b/src/components/layout/cell/Input.jsx
@@ -4,6 +4,10 @@ import {
     updateCellValue
 } from './../../../actions/plugins/editor/EditorActions';
 
+import {
+    nameFromDataIndex
+} from './../../../util/getData';
+
 export const Input = ({
     cellData,
     column,
@@ -14,10 +18,7 @@ export const Input = ({
     store
 }) => {
 
-    const colName = column
-        && column.dataIndex
-        ? column.dataIndex
-        : '';
+    const colName = nameFromDataIndex(column);
 
     const placeholder = column
         && column.placeholder
@@ -57,7 +58,7 @@ export const handleChange = (
     store.dispatch(
         updateCellValue({
             value: reactEvent.target.value,
-            name: columnDefinition.dataIndex,
+            name: nameFromDataIndex(columnDefinition),
             column: columnDefinition,
             columns,
             stateKey

--- a/src/reducers/components/plugins/editor.js
+++ b/src/reducers/components/plugins/editor.js
@@ -5,9 +5,13 @@ import {
     DISMISS_EDITOR,
     ROW_VALUE_CHANGE,
     CANCEL_ROW,
-    REMOVE_ROW,
-    EDITOR_VALIDATION
+    REMOVE_ROW
 } from '../../../constants/ActionTypes';
+
+import {
+    getData,
+    setDataAtDataIndex
+} from './../../../util/getData';
 
 const initialState = fromJS({
     editorState: fromJS.Map
@@ -25,7 +29,7 @@ export const isRowValid = (columns, rowValues) => {
     for (let i = 0; i < columns.length; i++) {
 
         const col = columns[i];
-        const val = isCellValid(col, rowValues[col.dataIndex]);
+        const val = isCellValid(col, getData(rowValues, columns, i));
 
         if (!val) {
             return false;
@@ -55,17 +59,18 @@ export default function editor(state = initialState, action) {
         });
 
     case ROW_VALUE_CHANGE:
-        const { columns, value, stateKey } = action;
+        const { column, columns, value, stateKey } = action;
         const previous = state.get(stateKey);
 
-        const rowValues = Object.assign({}, previous.row.values, {
-            [action.columnName]: value
-        });
+        const rowValues = setDataAtDataIndex(
+            previous.row.values, column.dataIndex, value
+        );
 
-        columns.forEach((col) => {
+        columns.forEach((col, i) => {
+            const val = getData(rowValues, columns, i);
             if (col.defaultValue !== undefined
-                && rowValues[col.dataIndex] === undefined) {
-                rowValues[col.dataIndex] = col.defaultValue;
+                && val === undefined || val === null) {
+                setDataAtDataIndex(rowValues, col.dataIndex, col.defaultValue);
             }
         });
 

--- a/src/util/getData.js
+++ b/src/util/getData.js
@@ -1,0 +1,86 @@
+import { camelize } from './camelize';
+
+export const getData = (
+    rowData = {}, columns = {}, colIndex = 0
+) => {
+
+    const column = columns[colIndex];
+
+    if (!column) {
+        return undefined;
+    }
+
+    const dataIndex = column.dataIndex || null;
+
+    if (!dataIndex) {
+        throw new Error('No dataIndex found on column', column);
+    }
+
+    if (typeof dataIndex === 'string') {
+        return rowData
+            && rowData[dataIndex] !== undefined
+            ? rowData[dataIndex]
+            : null;
+    }
+
+    else if (Array.isArray(dataIndex)) {
+        return getValueFromDataIndexArr(rowData, dataIndex);
+    }
+
+};
+
+export const setDataAtDataIndex = (rowData = {}, dataIndex, val) => {
+
+    if (typeof dataIndex === 'string') {
+        rowData[dataIndex] = val;
+        return rowData;
+    }
+
+    let temp = rowData;
+
+    for (let i = 0; i < dataIndex.length - 1; i++) {
+        temp = temp[dataIndex[i]];
+
+        if (!temp) {
+            return;
+        }
+    }
+
+    temp[dataIndex[dataIndex.length - 1]] = val;
+
+    return rowData;
+};
+
+export const getValueFromDataIndexArr = (rowData, dataIndex) => {
+    let temp = rowData;
+
+    for (let i = 0; i < dataIndex.length; i++) {
+        temp = temp[dataIndex[i]];
+
+        if (!temp) {
+            return '';
+        }
+    }
+
+    return temp;
+};
+
+export const nameFromDataIndex = (column) => {
+
+    if (!column) {
+        return '';
+    }
+
+    if (typeof column.dataIndex === 'string') {
+        return column.dataIndex;
+    }
+
+    if (Array.isArray(column.dataIndex)) {
+        return column.dataIndex[column.dataIndex.length - 1];
+    }
+
+    if (!column.dataIndex) {
+        return camelize(column.name);
+    }
+
+};

--- a/test/util/getData.test.js
+++ b/test/util/getData.test.js
@@ -1,0 +1,253 @@
+import expect from 'expect';
+import {
+    getData,
+    nameFromDataIndex,
+    getValueFromDataIndexArr,
+    setDataAtDataIndex
+} from './../../src/util/getData';
+
+describe('nameFromDataIndex utility function', () => {
+
+    it('Should work with a dataIndex', () => {
+
+        const column = {
+            dataIndex: 'someIndex',
+            name: 'A thing'
+        };
+
+        expect(
+            nameFromDataIndex(column)
+        ).toEqual(
+            'someIndex'
+        );
+
+    });
+
+    it('Should work with a name', () => {
+
+        const column = {
+            name: 'A thing'
+        };
+
+        expect(
+            nameFromDataIndex(column)
+        ).toEqual(
+            'aThing'
+        );
+
+    });
+
+    it('Should work with a string-array', () => {
+
+        const column = {
+            name: 'A thing',
+            dataIndex: ['some', 'nested', 'value']
+        };
+
+        expect(
+            nameFromDataIndex(column)
+        ).toEqual(
+            'value'
+        );
+
+    });
+
+});
+
+describe('getData utility function', () => {
+
+    it('Should fetch data with a string key', () => {
+
+        const rowData = {
+            col1: 'banana',
+            col2: 'orange',
+            col3: 'apple'
+        };
+
+        const columns = [
+            {
+                name: 'fruit',
+                dataIndex: 'col1'
+            },
+            {
+                name: 'another fruit',
+                dataIndex: 'col2'
+            },
+            {
+                name: 'yet another fruit',
+                dataIndex: 'col3'
+            }
+        ];
+
+        const colIndex = 1;
+
+        expect(getData(
+            rowData,
+            columns,
+            colIndex
+        )).toEqual(
+            'orange'
+        );
+
+    });
+
+    it('Should fetch data with a string-array key', () => {
+
+        const rowData = {
+            col1: {
+                innerKey: 'inner orange'
+            },
+            col2: 'orange',
+            col3: 'apple'
+        };
+
+        const columns = [
+            {
+                name: 'fruit',
+                dataIndex: ['col1', 'innerKey']
+            },
+            {
+                name: 'another fruit',
+                dataIndex: 'col2'
+            },
+            {
+                name: 'yet another fruit',
+                dataIndex: 'col3'
+            }
+        ];
+
+        const colIndex = 0;
+
+        expect(getData(
+            rowData,
+            columns,
+            colIndex
+        )).toEqual(
+            'inner orange'
+        );
+
+    });
+
+    it('Should return empty string if string-array isnt valid', () => {
+
+        const rowData = {
+            col1: {
+                innerKey: 'inner orange'
+            },
+            col2: 'orange',
+            col3: 'apple'
+        };
+
+        const columns = [
+            {
+                name: 'fruit',
+                dataIndex: ['col1', 'fakeKey']
+            },
+            {
+                name: 'another fruit',
+                dataIndex: 'col2'
+            },
+            {
+                name: 'yet another fruit',
+                dataIndex: 'col3'
+            }
+        ];
+
+        const colIndex = 0;
+
+        expect(getData(
+            rowData,
+            columns,
+            colIndex
+        )).toEqual(
+            ''
+        );
+
+    });
+});
+
+describe('setDataAtDataIndex function', () => {
+
+    it('Should work with nested object', () => {
+
+        const rowValues = {
+            outer: {
+                inner: 'oldValue'
+            }
+        };
+
+        expect(
+            setDataAtDataIndex(
+                rowValues,
+                ['outer', 'inner'],
+                'newValue'
+            )
+        ).toEqual({
+            outer: {
+                inner: 'newValue'
+            }
+        });
+    });
+
+    it('Should work with a string', () => {
+
+        const flatValues = {
+            val: 1
+        };
+
+        expect(
+            setDataAtDataIndex(
+                flatValues,
+                'val',
+                'newValue'
+            )
+        ).toEqual({
+            val: 'newValue'
+        });
+    });
+
+});
+
+describe('getValueFromDataIndexArr function', () => {
+
+    it('Should work with a nested object', () => {
+
+        const rowData = {
+            outer: {
+                inner: {
+                    superInner: {
+                        value: 'x'
+                    }
+                }
+            }
+        };
+
+        expect(
+            getValueFromDataIndexArr(
+                rowData,
+                ['outer', 'inner', 'superInner', 'value']
+            )
+        ).toEqual('x');
+    });
+
+    it('Should return empty string if the keys are invalid', () => {
+
+        const rowData = {
+            outer: {
+                inner: {
+                    superInner: {
+                        value: 'x'
+                    }
+                }
+            }
+        };
+
+        expect(
+            getValueFromDataIndexArr(
+                rowData,
+                ['outer', 'inner', 'fake', 'value']
+            )
+        ).toEqual('');
+    });
+
+});


### PR DESCRIPTION
Component now supports complex data structures for row data, as well as flat objects (which have always been supported).

Consider the following rowData 

    const data = {
		outer: {
			middle: {
				inner: 'rowValue'
			}
		}	
	};

Previously, you could not specify how a column should render this data. By providing the `dataIndex` as a string array, this data can now be displayed. 

The dataIndex for this example would be `['outer', 'middle', 'inner']` and would render `rowValue`.