### PR TITLE
feature/immutable-state

### DIFF
--- a/src/components/plugins/gridactions/ActionColumn.jsx
+++ b/src/components/plugins/gridactions/ActionColumn.jsx
@@ -45,8 +45,8 @@ export const ActionColumn = ({
     );
 
     const className = menuShown
-        ? prefix(actions.iconCls, 'active') || prefix(iconCls, 'active')
-        : prefix(actions.iconCls) || prefix(iconCls);
+        ? prefix(actions.iconCls || iconCls, 'active')
+        : prefix(actions.iconCls || iconCls);
 
     const iconProps = {
         className
@@ -305,7 +305,7 @@ export const handleHideMenu = (
     const menu = store.getState()[menuKey];
     const menuState = menu ? menu.get(stateKey) : null;
 
-    const headerMenuShown = menuState && menuState['header-row'];
+    const headerMenuShown = menuState && menuState.get('header-row');
 
     const hide = () => {
         setTimeout(() => { store.dispatch(hideMenu({ stateKey })); }, 0);

--- a/src/components/plugins/gridactions/ActionColumn.jsx
+++ b/src/components/plugins/gridactions/ActionColumn.jsx
@@ -301,7 +301,7 @@ export const handleHideMenu = (
         e.target, 'react-grid-action-container'
     );
 
-    const menuKey = reducerKeys.menu || 'Menu';
+    const menuKey = reducerKeys.menu || 'menu';
     const menu = store.getState()[menuKey];
     const menuState = menu ? menu.get(stateKey) : null;
 

--- a/src/components/plugins/gridactions/ActionColumn.jsx
+++ b/src/components/plugins/gridactions/ActionColumn.jsx
@@ -302,9 +302,8 @@ export const handleHideMenu = (
     );
 
     const menuKey = reducerKeys.menu || 'Menu';
-
-    const menuState = store.getState()[menuKey]
-        .get(stateKey);
+    const menu = store.getState()[menuKey];
+    const menuState = menu ? menu.get(stateKey) : null;
 
     const headerMenuShown = menuState && menuState['header-row'];
 

--- a/src/components/plugins/gridactions/actioncolumn/Menu.jsx
+++ b/src/components/plugins/gridactions/actioncolumn/Menu.jsx
@@ -59,7 +59,7 @@ Menu.propTypes = {
     reducerKeys: PropTypes.object,
     rowData: PropTypes.object,
     rowId: PropTypes.string,
-    rowIndex: PropTypes.string,
+    rowIndex: PropTypes.number,
     stateKey: PropTypes.string,
     store: PropTypes.object,
     type: PropTypes.string

--- a/src/reducers/components/datasource.js
+++ b/src/reducers/components/datasource.js
@@ -89,12 +89,14 @@ export default function dataSource(state = initialState, action) {
 
     case CLEAR_FILTER_LOCAL:
 
-        const existing = state.get(action.stateKey);
-        const recs = existing.proxy || existing.currentRecords;
+        const proxy = state.getIn([action.stateKey, 'proxy']);
+        const prevData = state.getIn([action.stateKey, 'data']);
+        const recs = proxy || prevData;
 
         return state.mergeIn([action.stateKey], {
             data: recs,
-            proxy: recs
+            proxy: recs,
+            currentRecords: recs
         });
 
     case FILTER_DATA:

--- a/src/reducers/components/grid.js
+++ b/src/reducers/components/grid.js
@@ -13,29 +13,19 @@ export default function gridState(state = initialState, action) {
     switch (action.type) {
 
     case SET_COLUMNS:
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             columns: action.columns
-        });
+        }));
 
     case SET_SORT_DIRECTION:
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             columns: action.columns
-        });
+        }));
 
     case RESIZE_COLUMNS:
-        return state.set(action.stateKey,
-            Object.assign({}, state.get('gridState'), {
-                columns: action.columns
-            })
-        );
-
-        // NOT USING IMMUTABLE
-        // THIS ACTION IS FIRED AT SUCH A HIGH RATE, NEED TO OPTIMIZE
-        // BY NOT USING IMMUTABLE STATE GETTER
-
-        // return state.setIn([action.stateKey], {
-        //     columns: action.columns
-        // });
+        return state.setIn([action.stateKey], fromJS({
+            columns: action.columns
+        }));
 
     default:
 

--- a/src/reducers/components/plugins/bulkaction.js
+++ b/src/reducers/components/plugins/bulkaction.js
@@ -11,9 +11,9 @@ export default function bulkaction(state = initialState, action) {
     switch (action.type) {
 
     case REMOVE_TOOLBAR:
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             isRemoved: action.value
-        });
+        }));
 
     default:
         return state;

--- a/src/reducers/components/plugins/editor.js
+++ b/src/reducers/components/plugins/editor.js
@@ -47,7 +47,7 @@ export default function editor(state = initialState, action) {
 
         const isValid = isRowValid(action.columns, action.values);
 
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             row: {
                 key: action.rowId,
                 values: action.values,
@@ -56,14 +56,14 @@ export default function editor(state = initialState, action) {
                 valid: isValid,
                 isCreate: action.isCreate || false
             }
-        });
+        }));
 
     case ROW_VALUE_CHANGE:
         const { column, columns, value, stateKey } = action;
-        const previous = state.get(stateKey);
+        const previousValues = state.getIn([stateKey, 'row', 'values']).toJS();
 
         const rowValues = setDataAtDataIndex(
-            previous.row.values, column.dataIndex, value
+            previousValues, column.dataIndex, value
         );
 
         columns.forEach((col, i) => {
@@ -76,22 +76,16 @@ export default function editor(state = initialState, action) {
 
         const valid = isRowValid(columns, rowValues);
 
-        return state.setIn([action.stateKey], {
-            row: {
-                key: previous.row.key,
-                values: rowValues,
-                rowIndex: previous.row.rowIndex,
-                previousValues: previous.row.values,
-                top: previous.row.top,
-                isCreate: previous.row.isCreate || false,
-                valid
-            }
-        });
+        return state.mergeIn([action.stateKey, 'row'], fromJS({
+            values: rowValues,
+            previousValues: state.getIn([stateKey, 'row', 'values']),
+            valid
+        }));
 
     case REMOVE_ROW:
     case DISMISS_EDITOR:
     case CANCEL_ROW:
-        return state.setIn([action.stateKey], {});
+        return state.setIn([action.stateKey], fromJS({}));
 
     default:
         return state;

--- a/src/reducers/components/plugins/errorhandler.js
+++ b/src/reducers/components/plugins/errorhandler.js
@@ -5,25 +5,23 @@ import {
     DISMISS_ERROR
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({
-    errorState: fromJS.Map
-});
+const initialState = fromJS({});
 
 export default function errorhandler(state = initialState, action) {
 
     switch (action.type) {
 
     case ERROR_OCCURRED:
-        return state.set('errorState', {
+        return state.set(action.stateKey, fromJS({
             error: action.error,
             errorOccurred: true
-        });
+        }));
 
     case DISMISS_ERROR:
-        return state.set('errorState', {
+        return state.set(action.stateKey, fromJS({
             error: '',
             errorOccurred: false
-        });
+        }));
 
     default:
         return state;

--- a/src/reducers/components/plugins/filter.js
+++ b/src/reducers/components/plugins/filter.js
@@ -6,9 +6,7 @@ import {
     SET_FILTER_MENU_VALUES
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({
-    filterState: fromJS.Map
-});
+const initialState = fromJS({});
 
 export default function filter(state = initialState, action) {
 
@@ -20,17 +18,20 @@ export default function filter(state = initialState, action) {
         });
 
     case SET_FILTER_MENU_VALUES:
+
+        const newValues = state
+            .mergeIn([action.stateKey, 'filterMenuValues'], action.filter)
+            .getIn([action.stateKey, 'filterMenuValues']);
+
         return state.mergeIn([action.stateKey], {
-            filterMenuValues: Object.assign(
-                state.get(action.stateKey).filterMenuValues || {}, action.filter
-            ),
+            filterMenuValues: newValues,
             filterMenuShown: true
         });
 
     case SHOW_FILTER_MENU:
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             filterMenuShown: action.metaData.filterMenuShown
-        });
+        }));
 
     default:
         return state;

--- a/src/reducers/components/plugins/menu.js
+++ b/src/reducers/components/plugins/menu.js
@@ -12,20 +12,18 @@ export default function menu(state = initialState, action) {
     switch (action.type) {
 
     case SHOW_MENU:
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             [action.id]: true
-        });
+        }));
 
     case HIDE_MENU:
         if (action.id) {
-            return state.setIn([action.stateKey], {
+            return state.setIn([action.stateKey], fromJS({
                 [action.id]: false
-            });
+            }));
         }
 
-        else {
-            return state.setIn([action.stateKey], {});
-        }
+        return state.setIn([action.stateKey], fromJS({}));
 
     default:
         return state;

--- a/src/reducers/components/plugins/pager.js
+++ b/src/reducers/components/plugins/pager.js
@@ -14,14 +14,14 @@ export default function pager(state = initialState, action) {
     switch (action.type) {
 
     case PAGE_LOCAL:
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             pageIndex: action.pageIndex
-        });
+        }));
 
     case PAGE_REMOTE:
-        return state.setIn([action.stateKey], {
+        return state.setIn([action.stateKey], fromJS({
             pageIndex: action.pageIndex
-        });
+        }));
 
     default:
         return state;

--- a/src/reducers/components/plugins/selection.js
+++ b/src/reducers/components/plugins/selection.js
@@ -13,27 +13,24 @@ export default function selection(state = initialState, action) {
     switch (action.type) {
 
     case SELECT_ALL:
-        return state.setIn([action.stateKey], action.selection);
+        return state.setIn([action.stateKey], fromJS(action.selection));
 
     case DESELECT_ALL:
-        return state.setIn([action.stateKey], {});
+        return state.setIn([action.stateKey], fromJS({}));
 
     case SET_SELECTION:
-
-        const currentValue = state.get(action.stateKey)
-            ? state.get(action.stateKey)[action.id]
-            : false;
+        const currentValue = state.getIn([action.stateKey, action.id]);
 
         if (action.clearSelections || !state.get(action.stateKey)) {
-            return state.setIn([action.stateKey], {
-                [action.id]: currentValue && action.allowDeselect ? false : true
-            });
+            return state.setIn([action.stateKey], fromJS({
+                [action.id]: action.allowDeselect ? !currentValue : true
+            }));
         }
 
-        // enable multiselect
-        return state.setIn([action.stateKey], {
-            [action.id]: currentValue && action.allowDeselect ? false : true
-        });
+        // multiselect
+        return state.mergeIn([action.stateKey], fromJS({
+            [action.id]: action.allowDeselect ? !currentValue : true
+        }));
 
     default:
         return state;

--- a/src/reducers/components/plugins/selection.js
+++ b/src/reducers/components/plugins/selection.js
@@ -16,7 +16,6 @@ export default function selection(state = initialState, action) {
         return state.setIn([action.stateKey], action.selection);
 
     case DESELECT_ALL:
-
         return state.setIn([action.stateKey], {});
 
     case SET_SELECTION:

--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -1,3 +1,15 @@
+/*
+* central function to retrieve state from reducer
+* used inside of mapStateToProps by grid and other plugins
+* @returns {object} state
+
+* will not return immutable object, only plain JS object
+
+* if a dynamic reducerKey is passed, it will favor that key
+* over the build in grid keys
+
+*/
+
 export function stateGetter(state, props, key, entry) {
 
     if (props
@@ -23,7 +35,7 @@ export function stateGetter(state, props, key, entry) {
         : null;
 
     if (firstTry) {
-        return firstTry;
+        return firstTry.toJS ? firstTry.toJS() : firstTry;
     }
 
     const keys = Object.keys(state);
@@ -33,12 +45,16 @@ export function stateGetter(state, props, key, entry) {
     const keyIndex = normalizedKeys.indexOf(key.toLowerCase());
 
     if (keyIndex !== -1) {
-        return state
+        const secondTry = state
             && state[keys[keyIndex]]
             && state[keys[keyIndex]].get
             && state[keys[keyIndex]].get(entry)
             ? state[keys[keyIndex]].get(entry)
             : null;
+
+        return secondTry && secondTry.toJS
+            ? secondTry.toJS()
+            : secondTry;
     }
 
     return null;

--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -19,12 +19,17 @@ export function stateGetter(state, props, key, entry) {
 
         const dynamicKey = props.reducerKeys[key];
 
-        return state
+        const dynamicState = state
             && state[dynamicKey]
             && state[dynamicKey].get
             && state[dynamicKey].get(entry)
             ? state[dynamicKey].get(entry)
             : null;
+
+        return dynamicState &&
+            dynamicState.toJS
+            ? dynamicState.toJS()
+            : dynamicState;
     }
 
     const firstTry = state

--- a/test/integration/plugins/gridactions.test.js
+++ b/test/integration/plugins/gridactions.test.js
@@ -1,0 +1,90 @@
+/* eslint-enable describe it sinon */
+import React from 'react';
+import expect from 'expect';
+import { mount } from 'enzyme';
+import { ConnectedGrid } from './../../../src/components/Grid.jsx';
+import { Store as GridStore } from './../../../src/store/store';
+
+import {
+    gridColumns,
+    localGridData,
+    stateKey
+} from '../../testUtils/data';
+
+const props = {
+    data: localGridData,
+    columns: gridColumns,
+    stateKey,
+    plugins: {}
+};
+
+describe('Integration Test for Grid Actions', () => {
+
+    const simpleProps = {
+        ...props,
+        store: GridStore,
+        plugins: {
+            GRID_ACTIONS: {
+                menu: [
+                    {
+                        text: 'Action 1',
+                        key: 'action1',
+                        EVENT_HANDLER: sinon.spy()
+                    },
+                    {
+                        text: 'Action 2',
+                        key: 'action2',
+                        EVENT_HANDLER: sinon.spy()
+                    }
+                ]
+            }
+        }
+    };
+
+    const component = mount(<ConnectedGrid { ...simpleProps } />, {
+        attachTo: document.body
+    });
+
+    it('Should render with the correct number of rows', () => {
+        expect(
+            component.find('.react-grid-row').length
+        ).toEqual(2);
+    });
+
+    it('Should render each row with action icons', () => {
+        // each row has an icon,
+        // + the hidden header, + the fixed (visible) header
+        expect(
+            component.find('.react-grid-action-icon').length
+        ).toEqual(4);
+    });
+
+    it('Should render each row with action icons', () => {
+        const rows = component.find('.react-grid-row');
+        const row1 = rows.first();
+
+        expect(
+            row1.find('.react-grid-action-icon').length
+        ).toEqual(1);
+
+    });
+
+    const row = component.find('.react-grid-row');
+    const icon = row.first()
+        .find('.react-grid-action-icon');
+
+    it('When clicked, the action icon should show a menu', (done) => {
+        icon.simulate('click');
+
+        setTimeout(() => {
+            expect(
+                row.find('.react-grid-action-container')
+                    .first()
+                    .props()
+                    .className
+            ).toContain('react-grid-action-menu-selected');
+            done();
+        }, 200);
+
+    });
+});

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -2,7 +2,7 @@ const loaders = require('../webpack/loaders');
 const path = require('path');
 const BROWSERS = process.argv && process.argv.indexOf('--browser') !== -1
     ? ['jsdom', 'Chrome']
-    : ['jsdom'];
+    : ['jsdom', 'Chrome'];
 
 module.exports = function exports(config) {
     config.set({

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,8 +1,7 @@
 const loaders = require('../webpack/loaders');
-const path = require('path');
 const BROWSERS = process.argv && process.argv.indexOf('--browser') !== -1
     ? ['jsdom', 'Chrome']
-    : ['jsdom', 'Chrome'];
+    : ['jsdom'];
 
 module.exports = function exports(config) {
     config.set({

--- a/test/reducers/components/datasource.test.js
+++ b/test/reducers/components/datasource.test.js
@@ -1,13 +1,16 @@
 /* eslint-enable describe it */
 import expect from 'expect';
-import { fromJS, List, Map } from 'immutable';
+import { fromJS } from 'immutable';
 
 import {
     SET_DATA,
     DISMISS_EDITOR,
     REMOVE_ROW,
     ADD_NEW_ROW,
-    SAVE_ROW
+    SAVE_ROW,
+    SORT_DATA,
+    CLEAR_FILTER_LOCAL,
+    FILTER_DATA
 } from './../../../src/constants/ActionTypes';
 
 import
@@ -28,21 +31,21 @@ describe('The grid dataSource reducer setData func', () => {
         };
 
         expect(
-            dataSource(state, action).toJS()
-        ).toEqual({
+            dataSource(state, action)
+        ).toEqual(fromJS({
             'test-grid': {
-                currentRecords: [
-                    { x: 1 }, { x: 2 }
-                ],
                 data: [
                     { x: 1 }, { x: 2 }
                 ],
                 proxy: [
                     { x: 1 }, { x: 2 }
                 ],
-                total: 2
+                total: 2,
+                currentRecords: [
+                    { x: 1 }, { x: 2 }
+                ]
             }
-        });
+        }));
 
     });
 
@@ -57,15 +60,15 @@ describe('The grid dataSource reducer setData func', () => {
         };
 
         expect(
-            dataSource(state, action).toJS()
-        ).toEqual({
+            dataSource(state, action)
+        ).toEqual(fromJS({
             'test-grid': {
-                currentRecords: [{ x: 1 }, { x: 2 }],
                 data: [{ x: 1 }, { x: 2 }],
                 proxy: [{ x: 1 }, { x: 2 }],
-                total: 2
+                total: 2,
+                currentRecords: [{ x: 1 }, { x: 2 }]
             }
-        });
+        }));
 
     });
 
@@ -83,15 +86,15 @@ describe('The grid dataSource reducer setData func', () => {
         };
 
         expect(
-            dataSource(state, action).toJS()
-        ).toEqual({
+            dataSource(state, action)
+        ).toEqual(fromJS({
             'test-grid': {
-                currentRecords: [{ banana: 2 }],
                 data: [{ x: 1 }, { x: 2 }],
                 proxy: [{ x: 1 }, { x: 2 }],
-                total: 2
+                total: 2,
+                currentRecords: [{ banana: 2 }]
             }
-        });
+        }));
 
     });
 
@@ -347,6 +350,173 @@ describe('The grid dataSource reducer saveRow func', () => {
             type: SAVE_ROW,
             rowIndex: 0,
             values: { cell: 'newValues' }
+        };
+
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
+
+    });
+
+});
+
+describe('The grid dataSource reducer sortData func', () => {
+
+    const inState = fromJS({
+        'test-grid': {
+            proxy: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            data: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            currentRecords: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            total: 2
+        }
+    });
+
+    it('Should update sort data', () => {
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: 2 },
+                    { cell: 1 }
+                ],
+                currentRecords: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                total: 2
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            type: SORT_DATA,
+            data: [
+                { cell: 2 },
+                { cell: 1 }
+            ]
+        };
+
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
+
+    });
+
+});
+
+describe('The grid dataSource reducer clearFilter func', () => {
+
+    const inState = fromJS({
+        'test-grid': {
+            proxy: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            data: [
+                { cell: 2 },
+                { cell: 1 }
+            ],
+            currentRecords: [
+                { cell: 2 },
+                { cell: 1 }
+            ],
+            total: 2
+        }
+    });
+
+    it('Should revert back to proxy if avail', () => {
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                currentRecords: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                total: 2
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            type: CLEAR_FILTER_LOCAL
+        };
+
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
+
+    });
+
+});
+
+describe('The grid dataSource reducer filterData func', () => {
+
+    const inState = fromJS({
+        'test-grid': {
+            proxy: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            data: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            currentRecords: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            total: 2
+        }
+    });
+
+    it('Should revert back to proxy if avail', () => {
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: 'newVals' },
+                    { cell: 'moreNewVals' }
+                ],
+                currentRecords: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                total: 2
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            type: FILTER_DATA,
+            data: [
+                { cell: 'newVals' },
+                { cell: 'moreNewVals' }
+            ]
         };
 
         expect(

--- a/test/reducers/components/datasource.test.js
+++ b/test/reducers/components/datasource.test.js
@@ -4,7 +4,10 @@ import { fromJS, List, Map } from 'immutable';
 
 import {
     SET_DATA,
-    DISMISS_EDITOR
+    DISMISS_EDITOR,
+    REMOVE_ROW,
+    ADD_NEW_ROW,
+    SAVE_ROW
 } from './../../../src/constants/ActionTypes';
 
 import
@@ -28,9 +31,15 @@ describe('The grid dataSource reducer setData func', () => {
             dataSource(state, action).toJS()
         ).toEqual({
             'test-grid': {
-                currentRecords: [{ x: 1 }, { x: 2 }],
-                data: [{ x: 1 }, { x: 2 }],
-                proxy: [{ x: 1 }, { x: 2 }],
+                currentRecords: [
+                    { x: 1 }, { x: 2 }
+                ],
+                data: [
+                    { x: 1 }, { x: 2 }
+                ],
+                proxy: [
+                    { x: 1 }, { x: 2 }
+                ],
                 total: 2
             }
         });
@@ -92,13 +101,32 @@ describe('The grid dataSource reducer dissmissEditor func', () => {
 
     it('Should wipe previous values upon dissmiss', () => {
 
-        const state = fromJS({
+        const inState = fromJS({
             'test-grid': {
                 proxy: [
                     { cell: 1 },
-                    { cell: 2}
+                    { cell: 2 }
                 ],
                 total: 2
+            }
+        });
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                total: 2,
+                data: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                currentRecords: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                isEditing: false
             }
         });
 
@@ -107,8 +135,224 @@ describe('The grid dataSource reducer dissmissEditor func', () => {
             type: DISMISS_EDITOR
         };
 
-        // expect(
-        //     dataSource(state, action)
-        // ).toEqual(state);
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
     });
+});
+
+describe('The grid dataSource reducer removeRow func', () => {
+
+    const inState = fromJS({
+        'test-grid': {
+            proxy: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            data: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            currentRecords: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            total: 2
+        }
+    });
+
+    it('Should remove row at 0 index of none is passed', () => {
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: 2 }
+                ],
+                currentRecords: [
+                    { cell: 2 }
+                ],
+                total: 2
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            type: REMOVE_ROW
+        };
+
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
+    });
+
+    it('Should remove row at 1 index if arg is passed', () => {
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 }
+                ],
+                data: [
+                    { cell: 1 }
+                ],
+                currentRecords: [
+                    { cell: 1 }
+                ],
+                total: 2
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            rowIndex: 1,
+            type: REMOVE_ROW
+        };
+
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
+
+    });
+
+});
+
+describe('The grid dataSource reducer addRow func', () => {
+
+    const inState = fromJS({
+        'test-grid': {
+            proxy: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            data: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            currentRecords: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            total: 2
+        }
+    });
+
+    it('Should add a new blank row if rows have been established', () => {
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: '' },
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                currentRecords: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                total: 2,
+                isEditing: true
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            type: ADD_NEW_ROW
+        };
+
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
+    });
+
+    it('Should add a new blank row if no rows have been established', () => {
+        const innerState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: [],
+                total: 0
+            }
+        });
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [{}],
+                currentRecords: [],
+                total: 0,
+                isEditing: true
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            type: ADD_NEW_ROW
+        };
+
+        expect(
+            dataSource(innerState, action)
+        ).toEqual(outState);
+    });
+
+});
+
+describe('The grid dataSource reducer saveRow func', () => {
+
+    const inState = fromJS({
+        'test-grid': {
+            proxy: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            data: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            currentRecords: [
+                { cell: 1 },
+                { cell: 2 }
+            ],
+            total: 2
+        }
+    });
+
+    it('Should update row values on save', () => {
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 'newValues' },
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: 'newValues' },
+                    { cell: 2 }
+                ],
+                currentRecords: [
+                    { cell: 'newValues' },
+                    { cell: 2 }
+                ],
+                total: 2
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            type: SAVE_ROW,
+            rowIndex: 0,
+            values: { cell: 'newValues' }
+        };
+
+        expect(
+            dataSource(inState, action)
+        ).toEqual(outState);
+
+    });
+
 });

--- a/test/reducers/components/grid.test.js
+++ b/test/reducers/components/grid.test.js
@@ -1,0 +1,94 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    SET_COLUMNS,
+    RESIZE_COLUMNS,
+    SET_SORT_DIRECTION
+} from './../../../src/constants/ActionTypes';
+
+import
+    grid
+from './../../../src/reducers/components/grid';
+
+const columns = [
+    {
+        name: 'col1',
+        renderer: () => {},
+        dataIndex: 'col-1'
+    },
+    {
+        name: 'col2',
+        dataIndex: 'col-2'
+    }
+];
+
+describe('The grid reducer setCol func', () => {
+
+    const state = fromJS({});
+
+    const action = {
+        stateKey: 'test-grid',
+        type: SET_COLUMNS,
+        columns
+    };
+
+    const outState = fromJS({
+        'test-grid': {
+            columns
+        }
+    });
+
+    it('Should set passing cols', () => {
+        expect(
+            grid(state, action)
+        ).toEqual(outState);
+    });
+
+});
+
+describe('The grid reducer SET_SORT_DIRECTION func', () => {
+    const state = fromJS({});
+
+    const action = {
+        stateKey: 'test-grid',
+        type: SET_SORT_DIRECTION,
+        columns
+    };
+
+    const outState = fromJS({
+        'test-grid': {
+            columns
+        }
+    });
+
+    it('Should set cols after sort action', () => {
+        expect(
+            grid(state, action)
+        ).toEqual(outState);
+    });
+});
+
+describe('The grid reducer resizeCols func', () => {
+    const state = fromJS({});
+
+    const action = {
+        stateKey: 'test-grid',
+        type: RESIZE_COLUMNS,
+        columns
+    };
+
+    const outState = fromJS({
+        'test-grid': {
+            columns
+        }
+    });
+
+    it('Should set cols after resize action', () => {
+        expect(
+            grid(state, action)
+        ).toEqual(outState);
+    });
+
+});

--- a/test/reducers/components/plugins/bulkaction.test.js
+++ b/test/reducers/components/plugins/bulkaction.test.js
@@ -1,0 +1,67 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    REMOVE_TOOLBAR
+} from './../../../../src/constants/ActionTypes';
+
+import
+    bulkaction
+from './../../../../src/reducers/components/plugins/bulkaction';
+
+describe('The bulkaction reducer', () => {
+
+    it('Should set toolbar as visible', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                isRemoved: true
+            }
+        });
+
+        const action = {
+            type: REMOVE_TOOLBAR,
+            value: false,
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            bulkaction(state, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {
+                    isRemoved: false
+                }
+            })
+        );
+
+    });
+
+    it('Should set toolbar as removed', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                isRemoved: false
+            }
+        });
+
+        const action = {
+            type: REMOVE_TOOLBAR,
+            value: true,
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            bulkaction(state, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {
+                    isRemoved: true
+                }
+            })
+        );
+
+    });
+
+});

--- a/test/reducers/components/plugins/editor.test.js
+++ b/test/reducers/components/plugins/editor.test.js
@@ -1,0 +1,420 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    EDIT_ROW,
+    DISMISS_EDITOR,
+    ROW_VALUE_CHANGE,
+    CANCEL_ROW,
+    REMOVE_ROW
+} from './../../../../src/constants/ActionTypes';
+
+import
+    editor,
+    { isCellValid, isRowValid }
+from './../../../../src/reducers/components/plugins/editor';
+
+describe('The editor reducer isCellValid func', () => {
+
+    it('Should use a validator if avail', () => {
+
+        const column = {
+            validator: ({ value }) => {
+                return value === 1;
+            },
+            name: 'One Column'
+        };
+
+        expect(
+            isCellValid(column, 1)
+        ).toEqual(true);
+
+    });
+
+    it('Should return valid if no validator is avail', () => {
+
+        const column = {
+            name: 'One Column'
+        };
+
+        expect(
+            isCellValid(column, 1)
+        ).toEqual(true);
+
+    });
+
+    it('Should return invalid with validator and bad val', () => {
+
+        const column = {
+            validator: ({ value }) => {
+                return value === 1;
+            },
+            name: 'One Column'
+        };
+
+        expect(
+            isCellValid(column, 2)
+        ).toEqual(false);
+
+    });
+
+});
+
+describe('The editor reducer isRowValid func', () => {
+
+    it('Should return a valid row', () => {
+
+        const columns = [
+            {
+                name: 'Column 1',
+                dataIndex: 'col1',
+                validator: ({ value }) => {
+                    return value === 1;
+                }
+            },
+            {
+                name: 'Column 2',
+                dataIndex: 'col2'
+            }
+        ];
+
+        const rowValues = {
+            col1: 1,
+            col2: NaN
+        };
+
+        expect(
+            isRowValid(columns, rowValues)
+        ).toEqual(true);
+
+    });
+
+    it('Should return an invalid row', () => {
+
+        const columns = [
+            {
+                name: 'Column 1',
+                dataIndex: 'col1',
+                validator: ({ value }) => {
+                    return value === 2;
+                }
+            },
+            {
+                name: 'Column 2',
+                dataIndex: 'col2'
+            }
+        ];
+
+        const rowValues = {
+            col1: 1,
+            col2: NaN
+        };
+
+        expect(
+            isRowValid(columns, rowValues)
+        ).toEqual(false);
+
+    });
+
+    it('Should return an valid if more cols exist than values', () => {
+
+        const columns = [
+            {
+                name: 'Column 1',
+                dataIndex: 'col1',
+                validator: ({ value }) => {
+                    return value === 1;
+                }
+            },
+            {
+                name: 'Column 2',
+                dataIndex: 'col2'
+            },
+            {
+                nane: 'banana',
+                dataIndex: 'banana'
+            }
+        ];
+
+        const rowValues = {
+            col1: 1,
+            col2: NaN
+        };
+
+        expect(
+            isRowValid(columns, rowValues)
+        ).toEqual(true);
+
+    });
+
+});
+
+describe('The editor reducer EDIT_ROW action', () => {
+
+    const state = fromJS({});
+
+    it('Should return the correct edit-not-create response', () => {
+
+        const action = {
+            type: EDIT_ROW,
+            stateKey: 'test-grid',
+            columns: [
+                {
+                    name: 'Col1',
+                    dataIndex: 'col1',
+                    validator: ({ value }) => {
+                        return value === 1;
+                    }
+                },
+                {
+                    name: 'Col2',
+                    dataIndex: 'col2'
+                }
+            ],
+            values: {
+                col1: 1,
+                col2: 2
+            },
+            rowIndex: 2,
+            rowId: 'rowid-2',
+            top: 30
+        };
+
+        expect(
+            editor(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                row: {
+                    key: 'rowid-2',
+                    values: {
+                        col1: 1,
+                        col2: 2
+                    },
+                    rowIndex: 2,
+                    top: 30,
+                    valid: true,
+                    isCreate: false
+                }
+            }
+        }));
+    });
+
+    it('Should return the correct edit-create response', () => {
+
+        const action = {
+            type: EDIT_ROW,
+            stateKey: 'test-grid',
+            columns: [
+                {
+                    name: 'Col1',
+                    dataIndex: 'col1',
+                    validator: ({ value }) => {
+                        return value === 2;
+                    }
+                },
+                {
+                    name: 'Col2',
+                    dataIndex: 'col2'
+                }
+            ],
+            values: {
+                col1: 1,
+                col2: 2
+            },
+            rowIndex: 2,
+            isCreate: true,
+            rowId: 'rowid-2',
+            top: 30
+        };
+
+        expect(
+            editor(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                row: {
+                    key: 'rowid-2',
+                    values: {
+                        col1: 1,
+                        col2: 2
+                    },
+                    rowIndex: 2,
+                    top: 30,
+                    valid: false,
+                    isCreate: true
+                }
+            }
+        }));
+
+    });
+
+});
+
+describe('The editor reducer ROW_VALUE_CHANGE action', () => {
+
+    it('Should return the correct rowValue change response', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                row: {
+                    key: 'rowid-2',
+                    values: {
+                        col1: NaN,
+                        col2: NaN
+                    },
+                    rowIndex: 2,
+                    top: 30,
+                    valid: false,
+                    isCreate: true
+                }
+            }
+        });
+
+        const action = {
+            type: ROW_VALUE_CHANGE,
+            columns: [
+                {
+                    name: 'Col1',
+                    dataIndex: 'col2',
+                    validator: ({ value }) => {
+                        return value === 1;
+                    }
+                },
+                {
+                    name: 'Col2',
+                    dataIndex: 'col2'
+                }
+            ],
+            column: {
+                name: 'Col1',
+                dataIndex: 'col2',
+                validator: ({ value }) => {
+                    return value === 1;
+                }
+            },
+            value: 1,
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            editor(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                row: {
+                    key: 'rowid-2',
+                    values: {
+                        col1: NaN,
+                        col2: 1
+                    },
+                    rowIndex: 2,
+                    top: 30,
+                    valid: true,
+                    isCreate: true,
+                    previousValues: {
+                        col1: NaN,
+                        col2: NaN
+                    }
+                }
+            }
+        }));
+
+    });
+
+});
+
+describe([
+    'The editor reducer REMOVE_ROW action, ',
+    'The editor reducer DISMISS_EDITOR action, ',
+    'The editor reducer CANCEL_ROW action'].join(''), () => {
+
+    it('Should wipe the values upon remove', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                row: {
+                    key: 'rowid-2',
+                    values: {
+                        col1: NaN,
+                        col2: NaN
+                    },
+                    rowIndex: 2,
+                    top: 30,
+                    valid: false,
+                    isCreate: true
+                }
+            }
+        });
+
+        const action = {
+            type: REMOVE_ROW,
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            editor(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {}
+        }));
+    });
+
+    it('Should wipe the values upon DISMISS_EDITOR', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                row: {
+                    key: 'rowid-2',
+                    values: {
+                        col1: NaN,
+                        col2: NaN
+                    },
+                    rowIndex: 2,
+                    top: 30,
+                    valid: false,
+                    isCreate: true
+                }
+            }
+        });
+
+        const action = {
+            type: DISMISS_EDITOR,
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            editor(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {}
+        }));
+    });
+
+    it('Should wipe the values upon CANCEL_ROW', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                row: {
+                    key: 'rowid-2',
+                    values: {
+                        col1: NaN,
+                        col2: NaN
+                    },
+                    rowIndex: 2,
+                    top: 30,
+                    valid: false,
+                    isCreate: true
+                }
+            }
+        });
+
+        const action = {
+            type: DISMISS_EDITOR,
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            editor(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {}
+        }));
+    });
+
+});

--- a/test/reducers/components/plugins/errorhandler.test.js
+++ b/test/reducers/components/plugins/errorhandler.test.js
@@ -1,0 +1,88 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    ERROR_OCCURRED,
+    DISMISS_ERROR
+} from './../../../../src/constants/ActionTypes';
+
+import
+    errorhandler
+from './../../../../src/reducers/components/plugins/errorhandler';
+
+describe('The errorhandler reducer', () => {
+
+    it('Should set an error if state was blank', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: ERROR_OCCURRED,
+            error: 'A generic error occurred dude',
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            errorhandler(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                error: 'A generic error occurred dude',
+                errorOccurred: true
+            }
+        }));
+
+    });
+
+    it('Should set an error if state was had an earlier error', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                error: 'A generic error occurred dude',
+                errorOccurred: true
+            }
+        });
+
+        const action = {
+            type: ERROR_OCCURRED,
+            error: 'A newer error happened',
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            errorhandler(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                error: 'A newer error happened',
+                errorOccurred: true
+            }
+        }));
+
+    });
+
+    it('Should wipe an error if state was had an earlier error', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                error: 'A generic error occurred dude',
+                errorOccurred: true
+            }
+        });
+
+        const action = {
+            type: DISMISS_ERROR,
+            stateKey: 'test-grid'
+        };
+
+        expect(
+            errorhandler(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                error: '',
+                errorOccurred: false
+            }
+        }));
+
+    });
+
+});

--- a/test/reducers/components/plugins/filter.test.js
+++ b/test/reducers/components/plugins/filter.test.js
@@ -1,0 +1,140 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    SET_FILTER_VALUE,
+    SHOW_FILTER_MENU,
+    SET_FILTER_MENU_VALUES
+} from './../../../../src/constants/ActionTypes';
+
+import
+    filter
+from './../../../../src/reducers/components/plugins/filter';
+
+describe('The filter reducer SET_FILTER_VALUE action', () => {
+
+    it('Should set a filter value, maintaining previous reducer state', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                filterMenuShown: true
+            }
+        });
+
+        const action = {
+            type: SET_FILTER_VALUE,
+            stateKey: 'test-grid',
+            value: {
+                someProp: 'filtering on prop'
+            }
+        };
+
+        expect(
+            filter(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                filterMenuShown: true,
+                filterValue: {
+                    someProp: 'filtering on prop'
+                }
+            }
+        }));
+
+    });
+
+});
+
+describe('The filter reducer SHOW_FILTER_MENU action', () => {
+
+    it('Should show filter menu, wiping previous state', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                filterMenuShown: false,
+                blah: 'someVal'
+            }
+        });
+
+        const action = {
+            type: SHOW_FILTER_MENU,
+            stateKey: 'test-grid',
+            metaData: {
+                filterMenuShown: true
+            }
+        };
+
+        expect(
+            filter(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                filterMenuShown: true
+            }
+        }));
+
+    });
+
+});
+
+describe('The filter reducer SET_FILTER_MENU_VALUES action', () => {
+
+    it('Should show filter menu, merging new filter vals with old', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                filterMenuShown: false,
+                filterMenuValues: {
+                    someProp: 1,
+                    newProp: 2
+                }
+            }
+        });
+
+        const action = {
+            type: SET_FILTER_MENU_VALUES,
+            stateKey: 'test-grid',
+            filter: {
+                newProp: 'newVal'
+            }
+        };
+
+        expect(
+            filter(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                filterMenuShown: true,
+                filterMenuValues: {
+                    someProp: 1,
+                    newProp: 'newVal'
+                }
+            }
+        }));
+
+    });
+
+    it('Should show filter menu, setting new filter if none existed', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: SET_FILTER_MENU_VALUES,
+            stateKey: 'test-grid',
+            filter: {
+                newProp: 'newVal'
+            }
+        };
+
+        expect(
+            filter(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                filterMenuValues: {
+                    newProp: 'newVal'
+                },
+                filterMenuShown: true
+            }
+        }));
+
+    });
+
+});

--- a/test/reducers/components/plugins/loader.test.js
+++ b/test/reducers/components/plugins/loader.test.js
@@ -1,0 +1,51 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    SET_LOADING_STATE
+} from './../../../../src/constants/ActionTypes';
+
+import
+    loader
+from './../../../../src/reducers/components/plugins/loader';
+
+describe('The loader reducer SET_LOADING_STATE action', () => {
+
+    it('Should set loading to true', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: SET_LOADING_STATE,
+            stateKey: 'test-grid',
+            state: true
+        };
+
+        expect(
+            loader(state, action)
+        ).toEqual(fromJS({
+            'test-grid': true
+        }));
+
+    });
+
+    it('Should set loading to false', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: SET_LOADING_STATE,
+            stateKey: 'test-grid',
+            state: false
+        };
+
+        expect(
+            loader(state, action)
+        ).toEqual(fromJS({
+            'test-grid': false
+        }));
+
+    });
+
+});

--- a/test/reducers/components/plugins/menu.test.js
+++ b/test/reducers/components/plugins/menu.test.js
@@ -1,0 +1,108 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    SHOW_MENU,
+    HIDE_MENU
+} from './../../../../src/constants/ActionTypes';
+
+import
+    menu
+from './../../../../src/reducers/components/plugins/menu';
+
+describe('The menu reducer SHOW_MENU action', () => {
+
+    it('Should show a menu, hiding the previously opened menu', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                oldId: true
+            }
+        });
+
+        const action = {
+            type: SHOW_MENU,
+            stateKey: 'test-grid',
+            id: 'newId'
+        };
+
+        expect(
+            menu(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                newId: true
+            }
+        }));
+
+    });
+
+    it('Should show a menu, even if none were open', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: SHOW_MENU,
+            stateKey: 'test-grid',
+            id: 'newId'
+        };
+
+        expect(
+            menu(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                newId: true
+            }
+        }));
+
+    });
+
+});
+
+describe('The menu reducer HIDE_MENU action', () => {
+
+    it('Should hide a menu, also hiding the previously opened menu', () => {
+
+        const state = fromJS({
+            'test-grid': {
+                oldId: true
+            }
+        });
+
+        const action = {
+            type: HIDE_MENU,
+            stateKey: 'test-grid',
+            id: 'newId'
+        };
+
+        expect(
+            menu(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                newId: false
+            }
+        }));
+
+    });
+
+    it('Should show a menu, even if none were open', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: HIDE_MENU,
+            stateKey: 'test-grid',
+            id: 'newId'
+        };
+
+        expect(
+            menu(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                newId: false
+            }
+        }));
+
+    });
+
+});

--- a/test/reducers/components/plugins/pager.test.js
+++ b/test/reducers/components/plugins/pager.test.js
@@ -1,0 +1,59 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    PAGE_LOCAL,
+    PAGE_REMOTE
+} from './../../../../src/constants/ActionTypes';
+
+import
+    pager
+from './../../../../src/reducers/components/plugins/pager';
+
+describe('The pager reducer PAGE_LOCAL action', () => {
+
+    it('Should set pageIndex locally', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: PAGE_LOCAL,
+            stateKey: 'test-grid',
+            pageIndex: 26
+        };
+
+        expect(
+            pager(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                pageIndex: 26
+            }
+        }));
+
+    });
+
+});
+
+describe('The pager reducer PAGE_REMOTE action', () => {
+
+    it('Should set pageIndex locally', () => {
+
+        const state = fromJS({});
+
+        const action = {
+            type: PAGE_REMOTE,
+            stateKey: 'test-grid',
+            pageIndex: 19
+        };
+
+        expect(
+            pager(state, action)
+        ).toEqual(fromJS({
+            'test-grid': {
+                pageIndex: 19
+            }
+        }));
+
+    });
+});

--- a/test/reducers/components/plugins/selection.test.js
+++ b/test/reducers/components/plugins/selection.test.js
@@ -1,0 +1,175 @@
+/* eslint-enable describe it */
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    SELECT_ALL,
+    SET_SELECTION,
+    DESELECT_ALL
+} from './../../../../src/constants/ActionTypes';
+
+import
+    selection
+from './../../../../src/reducers/components/plugins/selection';
+
+describe('The selectAll func in the selection reducer', () => {
+
+    const state = fromJS({
+        'test-grid': {
+            fakeRow: false,
+            anotherRow: false
+        }
+    });
+
+    const action = {
+        type: SELECT_ALL,
+        stateKey: 'test-grid',
+        selection: {
+            fakeRow: true,
+            anotherRow: true
+        }
+    };
+
+    it('Should return all rows as selected', () => {
+        expect(
+            selection(state, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {
+                    fakeRow: true,
+                    anotherRow: true
+                }
+            })
+        );
+    });
+
+});
+
+describe('The deselectAll func in the selection reducer', () => {
+
+    const state = fromJS({
+        'test-grid': {
+            fakeRow: false,
+            anotherRow: false
+        }
+    });
+
+    const action = {
+        type: DESELECT_ALL,
+        stateKey: 'test-grid'
+    };
+
+    it('Should return an empty map upon deselect', () => {
+        expect(
+            selection(state, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {}
+            })
+        );
+    });
+
+});
+
+describe('The setSelection func in the selection reducer', () => {
+
+    const state = fromJS({
+        'test-grid': {
+            fakeRow: true,
+            anotherRow: false
+        }
+    });
+
+    it(['Should should select a value and clear other values, ',
+        'and clearSelections is passed'].join(''), () => {
+
+        const action = {
+            type: SET_SELECTION,
+            stateKey: 'test-grid',
+            clearSelections: true,
+            id: 'anotherRow'
+        };
+
+        expect(
+            selection(state, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {
+                    anotherRow: true
+                }
+            })
+        );
+    });
+
+    it(['Should should deselect a value if already selected, ',
+        'and clearSelections is passed'].join(''), () => {
+
+        const action = {
+            type: SET_SELECTION,
+            stateKey: 'test-grid',
+            clearSelections: true,
+            allowDeselect: true,
+            id: 'fakeRow'
+        };
+
+        expect(
+            selection(state, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {
+                    fakeRow: false
+                }
+            })
+        );
+    });
+
+    it('Should select initial value if none are selected', () => {
+
+        const innerState = fromJS({});
+
+        const action = {
+            type: SET_SELECTION,
+            stateKey: 'test-grid',
+            id: 'fakeRow'
+        };
+
+        expect(
+            selection(innerState, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {
+                    fakeRow: true
+                }
+            })
+        );
+    });
+
+    it('Should allow multiselect if clearSelections is false', () => {
+
+        const selectedState = fromJS({
+            'test-grid': {
+                fakeRow: true
+            }
+        });
+
+        const action = {
+            type: SET_SELECTION,
+            stateKey: 'test-grid',
+            id: 'anotherRow',
+            clearSelections: false
+        };
+
+        expect(
+            selection(selectedState, action)
+        ).toEqual(
+            fromJS({
+                'test-grid': {
+                    fakeRow: true,
+                    anotherRow: true
+                }
+            })
+        );
+
+    });
+
+});

--- a/test/util/stateGetter.test.js
+++ b/test/util/stateGetter.test.js
@@ -1,4 +1,5 @@
 import expect from 'expect';
+import { fromJS } from 'immutable';
 import { stateGetter } from './../../src/util/stateGetter';
 
 describe('State Getter Function', () => {
@@ -8,12 +9,44 @@ describe('State Getter Function', () => {
         return true;
     }
 
+    function getStateWithImmutable(...props) {
+        return fromJS({
+            x: 1
+        });
+    }
+
     it('Should return state if its registered', () => {
         const state = { filterState: { get: getState } };
         const props = {};
         expect(
             stateGetter(state, props, 'filterState', 'someProp')
         ).toBeTruthy();
+    });
+
+    it(['Should return plain object if state is stored as a immutable',
+        ' and using a dynamic reducerKey'].join(''), () => {
+        const state = { someFilterState: { get: getStateWithImmutable } };
+        const props = {
+            reducerKeys: {
+                filterState: 'someFilterState'
+            }
+        };
+
+        expect(
+            stateGetter(state, props, 'someFilterState', 'someProp')
+        ).toEqual({
+            x: 1
+        });
+    });
+
+    it('Should return plain object if state is stored as a immutable', () => {
+        const state = { filterState: { get: getStateWithImmutable } };
+        const props = {};
+        expect(
+            stateGetter(state, props, 'filterState', 'someProp')
+        ).toEqual({
+            x: 1
+        });
     });
 
     it('Should return state even if the casing is off', () => {
@@ -39,7 +72,7 @@ describe('State Getter Function', () => {
         ).toEqual(null);
     });
 
-    it('Should return state when a dynamic key is used if it\'s registerd', () => {
+    it('Should return state when a dynamic key is used if registerd', () => {
         const state = { someFilterState: { get: getState } };
         const props = {
             reducerKeys: {
@@ -51,7 +84,7 @@ describe('State Getter Function', () => {
         ).toBeTruthy();
     });
 
-    it('Should return null when a dynamic key is used if it`\s not registered', () => {
+    it('Should return null if a dynamic key is used if not registered', () => {
         const state = {};
         const props = {
             reducerKeys: {
@@ -70,6 +103,5 @@ describe('State Getter Function', () => {
             stateGetter(state, props, 'filterState', 'someProp')
         ).toEqual(null);
     });
-
 
 });

--- a/test/util/stateGetter.test.js
+++ b/test/util/stateGetter.test.js
@@ -84,6 +84,21 @@ describe('State Getter Function', () => {
         ).toBeTruthy();
     });
 
+    it(['Should return state when a dynamic key ',
+        'is used, and has immutable state'].join(''), () => {
+        const state = { someFilterState: { get: getStateWithImmutable } };
+        const props = {
+            reducerKeys: {
+                filterState: 'someFilterState'
+            }
+        };
+        expect(
+            stateGetter(state, props, 'filterState', 'someProp')
+        ).toEqual({
+            x: 1
+        });
+    });
+
     it('Should return null if a dynamic key is used if not registered', () => {
         const state = {};
         const props = {


### PR DESCRIPTION
This MR solidifies how the grid stores and and creates state through core and plugin reducers. Although the component has always used immutable.js, it was inconsistent from one reducer to the next. The changes in this MR ensure that state is always stored as an immutable object, which makes testing how state is stored and created much simpler. As such, this MR also includes full testing of all reducers.

The only breaking change will be if users of the component have been manually reading grid state from their store, because instead of retrieving plain javascript `objects`, they will now recieve `immutable objects`. 

There is a simple fix for this scenario:

```
// previous to this MR
const gridState = store.getState()[GRID_REDUCER_KEY];

// now
const gridState = store.getState()[GRID_REDUCER_KEY].toJS();
```