### PR TITLE
Added some perf improvements to shouldComponentUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
   "main": "src/index.js",
   "scripts": {
     "test": "karma start ./test/karma.config.js",
-    "test-browser": "karma start ./test/karma.config.js --browser",
-    "watch-test": "",
+    "test-browser": "npm test -- --browser",
+    "test-watch": "npm test -- --no-single-run --no-suppress-error-summary",
     "build": "webpack --pretty --config webpack/webpack.config.dev.js",
+    "lint": "eslint ./src",
     "prod": "webpack -p --config webpack/webpack.config.prod.js",
     "hot": "webpack-dev-server --hot --inline --pretty --config webpack/webpack.config.hot.js"
   },
   "dependencies": {
+    "deep-equal": "^1.0.1",
     "font-awesome": "^4.6.1",
     "immutable": "^3.8.1",
     "react": "^15.0.1",

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -30,7 +30,7 @@ class Grid extends Component {
             columnState,
             gridData,
             height,
-            isLoading,
+            loadingState,
             pageSize,
             plugins,
             events,
@@ -163,7 +163,7 @@ class Grid extends Component {
             reducerKeys,
             stateKey,
             store,
-            isLoading
+            loadingState
         };
 
         return (
@@ -250,7 +250,7 @@ class Grid extends Component {
             PropTypes.string,
             PropTypes.number
         ]),
-        isLoading: PropTypes.bool,
+        loadingState: PropTypes.object,
         menuState: PropTypes.object,
         pageSize: PropTypes.number,
         pager: PropTypes.object,

--- a/src/components/plugins/loader/LoadingBar.jsx
+++ b/src/components/plugins/loader/LoadingBar.jsx
@@ -3,7 +3,13 @@ import { prefix } from '../../../util/prefix';
 import { isPluginEnabled } from '../../../util/isPluginEnabled';
 import { CLASS_NAMES } from '../../../constants/GridConstants';
 
-export const LoadingBar = ({ isLoading, plugins }) => {
+export const LoadingBar = ({ loadingState, plugins }) => {
+
+    let isLoading = false;
+
+    if (loadingState && loadingState.isLoading) {
+        isLoading = true;
+    }
 
     const showLoader = isPluginEnabled(plugins, 'LOADER')
         && isLoading;
@@ -18,11 +24,13 @@ export const LoadingBar = ({ isLoading, plugins }) => {
 };
 
 LoadingBar.propTypes = {
-    isLoading: PropTypes.bool,
+    loadingState: PropTypes.object,
     plugins: PropTypes.object,
     store: PropTypes.object
 };
 
-LoadingBar.defaultProps = {};
+LoadingBar.defaultProps = {
+    loadingState: {}
+};
 
 export default LoadingBar;

--- a/src/reducers/components/datasource.js
+++ b/src/reducers/components/datasource.js
@@ -9,7 +9,9 @@ import { SET_DATA,
     SORT_DATA
 } from '../../constants/ActionTypes';
 
-const initialState = fromJS({});
+import { generateLastUpdate } from './../../util/lastUpdate';
+
+const initialState = fromJS({ lastUpdate: generateLastUpdate() });
 
 export default function dataSource(state = initialState, action) {
     switch (action.type) {
@@ -19,7 +21,8 @@ export default function dataSource(state = initialState, action) {
             data: action.data,
             proxy: action.data,
             total: action.total || action.data.length,
-            currentRecords: action.currentRecords || action.data
+            currentRecords: action.currentRecords || action.data,
+            lastUpdate: generateLastUpdate()
         }));
 
     case DISMISS_EDITOR:
@@ -32,7 +35,8 @@ export default function dataSource(state = initialState, action) {
                 proxy: previousProxy,
                 currentRecords: previousProxy,
                 total: previousTotal,
-                isEditing: false
+                isEditing: false,
+                lastUpdate: generateLastUpdate()
             }));
         }
 
@@ -46,7 +50,8 @@ export default function dataSource(state = initialState, action) {
         return state.mergeIn([action.stateKey], fromJS({
             data: remainingRows,
             proxy: remainingRows,
-            currentRecords: remainingRows
+            currentRecords: remainingRows,
+            lastUpdate: generateLastUpdate()
         }));
 
     case ADD_NEW_ROW:
@@ -68,7 +73,8 @@ export default function dataSource(state = initialState, action) {
         return state.mergeIn([action.stateKey], fromJS({
             data: data.unshift(newRow),
             proxy: data,
-            isEditing: true
+            isEditing: true,
+            lastUpdate: generateLastUpdate()
         }));
 
     case SAVE_ROW:
@@ -79,12 +85,14 @@ export default function dataSource(state = initialState, action) {
         return state.mergeIn([action.stateKey], fromJS({
             data: gridData,
             proxy: gridData,
-            currentRecords: gridData
+            currentRecords: gridData,
+            lastUpdate: generateLastUpdate()
         }));
 
     case SORT_DATA:
         return state.mergeIn([action.stateKey], {
-            data: action.data
+            data: action.data,
+            lastUpdate: generateLastUpdate()
         });
 
     case CLEAR_FILTER_LOCAL:
@@ -96,12 +104,14 @@ export default function dataSource(state = initialState, action) {
         return state.mergeIn([action.stateKey], {
             data: recs,
             proxy: recs,
-            currentRecords: recs
+            currentRecords: recs,
+            lastUpdate: generateLastUpdate()
         });
 
     case FILTER_DATA:
         return state.mergeIn([action.stateKey], {
-            data: action.data
+            data: action.data,
+            lastUpdate: generateLastUpdate()
         });
 
     default:

--- a/src/reducers/components/grid.js
+++ b/src/reducers/components/grid.js
@@ -4,9 +4,11 @@ import {
     SET_COLUMNS,
     RESIZE_COLUMNS,
     SET_SORT_DIRECTION
-} from '../../constants/ActionTypes';
+} from './../../constants/ActionTypes';
 
-const initialState = fromJS({});
+import { generateLastUpdate } from './../../util/lastUpdate';
+
+const initialState = fromJS({ lastUpdate: generateLastUpdate() });
 
 export default function gridState(state = initialState, action) {
 
@@ -14,17 +16,20 @@ export default function gridState(state = initialState, action) {
 
     case SET_COLUMNS:
         return state.setIn([action.stateKey], fromJS({
-            columns: action.columns
+            columns: action.columns,
+            lastUpdate: generateLastUpdate()
         }));
 
     case SET_SORT_DIRECTION:
         return state.setIn([action.stateKey], fromJS({
-            columns: action.columns
+            columns: action.columns,
+            lastUpdate: generateLastUpdate()
         }));
 
     case RESIZE_COLUMNS:
         return state.setIn([action.stateKey], fromJS({
-            columns: action.columns
+            columns: action.columns,
+            lastUpdate: generateLastUpdate()
         }));
 
     default:

--- a/src/reducers/components/plugins/bulkaction.js
+++ b/src/reducers/components/plugins/bulkaction.js
@@ -2,9 +2,11 @@ import { fromJS } from 'immutable';
 
 import {
     REMOVE_TOOLBAR
-} from '../../../constants/ActionTypes';
+} from './../../../constants/ActionTypes';
 
-const initialState = fromJS({});
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
+const initialState = fromJS({ lastUpdate: generateLastUpdate() });
 
 export default function bulkaction(state = initialState, action) {
 
@@ -12,7 +14,8 @@ export default function bulkaction(state = initialState, action) {
 
     case REMOVE_TOOLBAR:
         return state.setIn([action.stateKey], fromJS({
-            isRemoved: action.value
+            isRemoved: action.value,
+            lastUpdate: generateLastUpdate()
         }));
 
     default:

--- a/src/reducers/components/plugins/editor.js
+++ b/src/reducers/components/plugins/editor.js
@@ -13,8 +13,10 @@ import {
     setDataAtDataIndex
 } from './../../../util/getData';
 
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
 const initialState = fromJS({
-    editorState: fromJS.Map
+    lastUpdate: generateLastUpdate()
 });
 
 export const isCellValid = ({ validator }, value) => {
@@ -55,7 +57,8 @@ export default function editor(state = initialState, action) {
                 top: action.top,
                 valid: isValid,
                 isCreate: action.isCreate || false
-            }
+            },
+            lastUpdate: generateLastUpdate()
         }));
 
     case ROW_VALUE_CHANGE:
@@ -76,16 +79,24 @@ export default function editor(state = initialState, action) {
 
         const valid = isRowValid(columns, rowValues);
 
-        return state.mergeIn([action.stateKey, 'row'], fromJS({
+        state = state.mergeIn([action.stateKey, 'row'], {
             values: rowValues,
             previousValues: state.getIn([stateKey, 'row', 'values']),
             valid
-        }));
+        });
+
+        return state.setIn(
+            [action.stateKey, 'lastUpdate'],
+            generateLastUpdate()
+        );
 
     case REMOVE_ROW:
     case DISMISS_EDITOR:
     case CANCEL_ROW:
-        return state.setIn([action.stateKey], fromJS({}));
+        return state.setIn(
+            [action.stateKey],
+            fromJS({ lastUpdate: generateLastUpdate() })
+        );
 
     default:
         return state;

--- a/src/reducers/components/plugins/errorhandler.js
+++ b/src/reducers/components/plugins/errorhandler.js
@@ -5,7 +5,9 @@ import {
     DISMISS_ERROR
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({});
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
+const initialState = fromJS({ lastUpdate: generateLastUpdate() });
 
 export default function errorhandler(state = initialState, action) {
 
@@ -14,13 +16,15 @@ export default function errorhandler(state = initialState, action) {
     case ERROR_OCCURRED:
         return state.set(action.stateKey, fromJS({
             error: action.error,
-            errorOccurred: true
+            errorOccurred: true,
+            lastUpdate: generateLastUpdate()
         }));
 
     case DISMISS_ERROR:
         return state.set(action.stateKey, fromJS({
             error: '',
-            errorOccurred: false
+            errorOccurred: false,
+            lastUpdate: generateLastUpdate()
         }));
 
     default:

--- a/src/reducers/components/plugins/filter.js
+++ b/src/reducers/components/plugins/filter.js
@@ -6,7 +6,9 @@ import {
     SET_FILTER_MENU_VALUES
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({});
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
+const initialState = fromJS({ lastUpdate: generateLastUpdate() });
 
 export default function filter(state = initialState, action) {
 
@@ -14,7 +16,8 @@ export default function filter(state = initialState, action) {
 
     case SET_FILTER_VALUE:
         return state.mergeIn([action.stateKey], {
-            filterValue: action.value
+            filterValue: action.value,
+            lastUpdate: generateLastUpdate()
         });
 
     case SET_FILTER_MENU_VALUES:
@@ -25,12 +28,14 @@ export default function filter(state = initialState, action) {
 
         return state.mergeIn([action.stateKey], {
             filterMenuValues: newValues,
-            filterMenuShown: true
+            filterMenuShown: true,
+            lastUpdate: generateLastUpdate()
         });
 
     case SHOW_FILTER_MENU:
         return state.setIn([action.stateKey], fromJS({
-            filterMenuShown: action.metaData.filterMenuShown
+            filterMenuShown: action.metaData.filterMenuShown,
+            lastUpdate: generateLastUpdate()
         }));
 
     default:

--- a/src/reducers/components/plugins/loader.js
+++ b/src/reducers/components/plugins/loader.js
@@ -4,8 +4,10 @@ import {
     SET_LOADING_STATE
 } from '../../../constants/ActionTypes';
 
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
 const initialState = fromJS({
-    loaderState: fromJS.Map
+    lastUpdate: generateLastUpdate()
 });
 
 export default function loader(state = initialState, action) {
@@ -13,7 +15,10 @@ export default function loader(state = initialState, action) {
     switch (action.type) {
 
     case SET_LOADING_STATE:
-        return state.setIn([action.stateKey], action.state);
+        return state.mergeIn([action.stateKey], {
+            isLoading: action.state,
+            lastUpdate: generateLastUpdate()
+        });
 
     default:
         return state;

--- a/src/reducers/components/plugins/menu.js
+++ b/src/reducers/components/plugins/menu.js
@@ -5,7 +5,9 @@ import {
     HIDE_MENU
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({});
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
+const initialState = fromJS({ lastUpdate: generateLastUpdate() });
 
 export default function menu(state = initialState, action) {
 
@@ -13,17 +15,22 @@ export default function menu(state = initialState, action) {
 
     case SHOW_MENU:
         return state.setIn([action.stateKey], fromJS({
-            [action.id]: true
+            [action.id]: true,
+            lastUpdate: generateLastUpdate()
         }));
 
     case HIDE_MENU:
         if (action.id) {
             return state.setIn([action.stateKey], fromJS({
-                [action.id]: false
+                [action.id]: false,
+                lastUpdate: generateLastUpdate()
             }));
         }
 
-        return state.setIn([action.stateKey], fromJS({}));
+        return state.setIn(
+            [action.stateKey],
+            fromJS({ lastUpdate: generateLastUpdate() })
+        );
 
     default:
         return state;

--- a/src/reducers/components/plugins/pager.js
+++ b/src/reducers/components/plugins/pager.js
@@ -5,8 +5,10 @@ import {
     PAGE_REMOTE
 } from '../../../constants/ActionTypes';
 
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
 const initialState = fromJS({
-    pagerState: fromJS.Map
+    lastUpdate: generateLastUpdate()
 });
 
 export default function pager(state = initialState, action) {
@@ -14,14 +16,16 @@ export default function pager(state = initialState, action) {
     switch (action.type) {
 
     case PAGE_LOCAL:
-        return state.setIn([action.stateKey], fromJS({
-            pageIndex: action.pageIndex
-        }));
+        return state.mergeIn([action.stateKey], {
+            pageIndex: action.pageIndex,
+            lastUpdate: generateLastUpdate()
+        });
 
     case PAGE_REMOTE:
-        return state.setIn([action.stateKey], fromJS({
-            pageIndex: action.pageIndex
-        }));
+        return state.mergeIn([action.stateKey], {
+            pageIndex: action.pageIndex,
+            lastUpdate: generateLastUpdate()
+        });
 
     default:
         return state;

--- a/src/reducers/components/plugins/selection.js
+++ b/src/reducers/components/plugins/selection.js
@@ -6,30 +6,39 @@ import {
     DESELECT_ALL
 } from '../../../constants/ActionTypes';
 
-const initialState = fromJS({});
+import { generateLastUpdate } from './../../../util/lastUpdate';
+
+const initialState = fromJS({ lastUpdate: generateLastUpdate() });
 
 export default function selection(state = initialState, action) {
 
     switch (action.type) {
 
     case SELECT_ALL:
-        return state.setIn([action.stateKey], fromJS(action.selection));
+        return state.setIn([action.stateKey], fromJS({
+            ...action.selection,
+            lastUpdate: generateLastUpdate()
+        }));
 
     case DESELECT_ALL:
-        return state.setIn([action.stateKey], fromJS({}));
+        return state.setIn([action.stateKey], fromJS({
+            lastUpdate: generateLastUpdate()
+        }));
 
     case SET_SELECTION:
         const currentValue = state.getIn([action.stateKey, action.id]);
 
         if (action.clearSelections || !state.get(action.stateKey)) {
             return state.setIn([action.stateKey], fromJS({
-                [action.id]: action.allowDeselect ? !currentValue : true
+                [action.id]: action.allowDeselect ? !currentValue : true,
+                lastUpdate: generateLastUpdate()
             }));
         }
 
         // multiselect
         return state.mergeIn([action.stateKey], fromJS({
-            [action.id]: action.allowDeselect ? !currentValue : true
+            [action.id]: action.allowDeselect ? !currentValue : true,
+            lastUpdate: generateLastUpdate()
         }));
 
     default:

--- a/src/util/lastUpdate.js
+++ b/src/util/lastUpdate.js
@@ -1,0 +1,37 @@
+let num = 0;
+
+const REDUCER_KEYS = {
+    BulkActions: 'bulkaction',
+    DataSource: 'dataSource',
+    Editor: 'editor',
+    ErrorHandler: 'errorhandler',
+    Filter: 'filter',
+    Grid: 'grid',
+    Loader: 'loader',
+    Menu: 'menu',
+    Pager: 'pager',
+    Selection: 'selection'
+};
+
+export const generateLastUpdate = () => ++num;
+
+export const resetLastUpdate = () => { num = 0; };
+
+export const getLastUpdate = (store, key, reducerKeys = REDUCER_KEYS) => {
+    const state = store.getState();
+
+    let keys = Object.keys(reducerKeys);
+
+    if (!keys.length) {
+        reducerKeys = REDUCER_KEYS;
+        keys = Object.keys(REDUCER_KEYS);
+    }
+
+    return keys.reduce((prev, reducerAccessor) => {
+        const reducerKey = reducerKeys[reducerAccessor];
+        if (state[reducerKey] && state[reducerKey].toJS) {
+            prev[reducerKey] = state[reducerKey].getIn([key, 'lastUpdate']);
+        }
+        return prev;
+    }, {});
+};

--- a/src/util/mapStateToProps.js
+++ b/src/util/mapStateToProps.js
@@ -8,6 +8,6 @@ export function mapStateToProps(state, props) {
         pager: stateGetter(state, props, 'pager', props.stateKey),
         selectedRows: stateGetter(state, props, 'selection', props.stateKey),
         menuState: stateGetter(state, props, 'menu', props.stateKey),
-        isLoading: stateGetter(state, props, 'loader', props.stateKey)
+        loadingState: stateGetter(state, props, 'loader', props.stateKey)
     };
 }

--- a/src/util/shouldComponentUpdate.js
+++ b/src/util/shouldComponentUpdate.js
@@ -1,45 +1,28 @@
 import { fromJS, is } from 'immutable';
-import { mapStateToProps } from './mapStateToProps';
+import deepEqual from 'deep-equal';
 import { keyGenerator } from './keyGenerator';
+import { getLastUpdate } from './lastUpdate';
 
 export function shouldGridUpdate(nextProps) {
     let result = true;
 
-    try {
-        const { store } = this.props;
+    const { reducerKeys, stateKey, store } = this.props;
 
-        const propsWithoutPlugins = {
-            ...this.props,
-            plugins: {},
-            columns: ''
-        };
+    const nextUpdate = getLastUpdate(store, stateKey, reducerKeys);
 
-        const nextPropsWithoutPlugins = {
-            ...nextProps,
-            plugins: {},
-            columns: ''
-        };
+    result = (
+        !deepEqual(nextUpdate, this._lastUpdate)
+        || !equalProps(nextProps, this._lastProps)
+    );
 
-        const nextStateProps =
-            fromJS(mapStateToProps(store.getState(), propsWithoutPlugins));
-
-        nextProps = fromJS(nextPropsWithoutPlugins);
-
-        result = (
-            !is(nextProps, this._lastProps)
-            || !is(nextStateProps, this._stateProps)
-        );
-
-        this._stateProps = nextStateProps;
-        this._lastProps = nextProps;
-    } catch (e) { } // eslint-disable-line
+    this._lastUpdate = nextUpdate;
+    this._lastProps = nextProps;
 
     return result;
 }
 
 export function shouldRowUpdate(nextProps) {
     let result = true;
-
     const {
         columns,
         editorState,
@@ -93,3 +76,9 @@ export function shouldRowUpdate(nextProps) {
 
     return result;
 }
+
+export const equalProps = (props = {}, newProps = {}) => {
+    return props.height === newProps.height
+        && deepEqual(props.classNames, newProps.classNames)
+        && deepEqual(props.events, newProps.events);
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,26 @@
 import * as imports from './../src/';
+import { is } from 'immutable';
 import expect from 'expect';
+import { diff } from 'deep-diff';
+
+expect.extend({
+    toEqualImmutable(expected) {
+        expect.assert(
+            is(this.actual, expected),
+            'Expected \n%s\nto be equivalent to actual \n%s\n Diff: %s',
+            expected,
+            this.actual,
+            diff(
+                expected && expected.toJS
+                    ? expected.toJS()
+                    : expected,
+                this.actual && this.actual.toJS
+                    ? this.actual.toJS()
+                    : this.actual
+            )
+        );
+    }
+});
 
 function reducerTest(reducerKey) {
     expect(imports.Reducers[reducerKey]).toBeTruthy();

--- a/test/integration/plugins/gridactions.test.js
+++ b/test/integration/plugins/gridactions.test.js
@@ -84,7 +84,7 @@ describe('Integration Test for Grid Actions', () => {
                     .className
             ).toContain('react-grid-action-menu-selected');
             done();
-        }, 200);
+        }, 1000);
 
     });
 });

--- a/test/reducers/components/datasource.test.js
+++ b/test/reducers/components/datasource.test.js
@@ -17,7 +17,12 @@ import
     dataSource
 from './../../../src/reducers/components/datasource';
 
+import {
+    resetLastUpdate
+} from './../../../src/util/lastUpdate';
+
 describe('The grid dataSource reducer setData func', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should set data with a total', () => {
 
@@ -27,12 +32,12 @@ describe('The grid dataSource reducer setData func', () => {
             stateKey: 'test-grid',
             type: SET_DATA,
             total: 2,
-            data: [{x: 1}, {x: 2}]
+            data: [{ x: 1 }, { x: 2 }]
         };
 
         expect(
             dataSource(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 data: [
                     { x: 1 }, { x: 2 }
@@ -43,7 +48,8 @@ describe('The grid dataSource reducer setData func', () => {
                 total: 2,
                 currentRecords: [
                     { x: 1 }, { x: 2 }
-                ]
+                ],
+                lastUpdate: 1
             }
         }));
 
@@ -61,12 +67,13 @@ describe('The grid dataSource reducer setData func', () => {
 
         expect(
             dataSource(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 data: [{ x: 1 }, { x: 2 }],
                 proxy: [{ x: 1 }, { x: 2 }],
                 total: 2,
-                currentRecords: [{ x: 1 }, { x: 2 }]
+                currentRecords: [{ x: 1 }, { x: 2 }],
+                lastUpdate: 1
             }
         }));
 
@@ -82,17 +89,19 @@ describe('The grid dataSource reducer setData func', () => {
             data: [{x: 1}, {x: 2}],
             currentRecords: [
                 { banana: 2 }
-            ]
+            ],
+            lastUpdate: 1
         };
 
         expect(
             dataSource(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 data: [{ x: 1 }, { x: 2 }],
                 proxy: [{ x: 1 }, { x: 2 }],
                 total: 2,
-                currentRecords: [{ banana: 2 }]
+                currentRecords: [{ banana: 2 }],
+                lastUpdate: 1
             }
         }));
 
@@ -101,6 +110,7 @@ describe('The grid dataSource reducer setData func', () => {
 });
 
 describe('The grid dataSource reducer dissmissEditor func', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should wipe previous values upon dissmiss', () => {
 
@@ -129,7 +139,8 @@ describe('The grid dataSource reducer dissmissEditor func', () => {
                     { cell: 1 },
                     { cell: 2 }
                 ],
-                isEditing: false
+                isEditing: false,
+                lastUpdate: 1
             }
         });
 
@@ -140,11 +151,12 @@ describe('The grid dataSource reducer dissmissEditor func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
     });
 });
 
 describe('The grid dataSource reducer removeRow func', () => {
+    beforeEach(() => resetLastUpdate());
 
     const inState = fromJS({
         'test-grid': {
@@ -160,7 +172,8 @@ describe('The grid dataSource reducer removeRow func', () => {
                 { cell: 1 },
                 { cell: 2 }
             ],
-            total: 2
+            total: 2,
+            lastUpdate: 1
         }
     });
 
@@ -177,7 +190,8 @@ describe('The grid dataSource reducer removeRow func', () => {
                 currentRecords: [
                     { cell: 2 }
                 ],
-                total: 2
+                total: 2,
+                lastUpdate: 1
             }
         });
 
@@ -188,7 +202,7 @@ describe('The grid dataSource reducer removeRow func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
     });
 
     it('Should remove row at 1 index if arg is passed', () => {
@@ -204,7 +218,8 @@ describe('The grid dataSource reducer removeRow func', () => {
                 currentRecords: [
                     { cell: 1 }
                 ],
-                total: 2
+                total: 2,
+                lastUpdate: 1
             }
         });
 
@@ -216,13 +231,14 @@ describe('The grid dataSource reducer removeRow func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
 
     });
 
 });
 
 describe('The grid dataSource reducer addRow func', () => {
+    beforeEach(() => resetLastUpdate());
 
     const inState = fromJS({
         'test-grid': {
@@ -259,7 +275,8 @@ describe('The grid dataSource reducer addRow func', () => {
                     { cell: 2 }
                 ],
                 total: 2,
-                isEditing: true
+                isEditing: true,
+                lastUpdate: 1
             }
         });
 
@@ -270,7 +287,7 @@ describe('The grid dataSource reducer addRow func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
     });
 
     it('Should add a new blank row if no rows have been established', () => {
@@ -279,7 +296,8 @@ describe('The grid dataSource reducer addRow func', () => {
                 proxy: [],
                 data: [],
                 currentRecords: [],
-                total: 0
+                total: 0,
+                lastUpdate: 1
             }
         });
 
@@ -289,7 +307,8 @@ describe('The grid dataSource reducer addRow func', () => {
                 data: [{}],
                 currentRecords: [],
                 total: 0,
-                isEditing: true
+                isEditing: true,
+                lastUpdate: 1
             }
         });
 
@@ -300,12 +319,13 @@ describe('The grid dataSource reducer addRow func', () => {
 
         expect(
             dataSource(innerState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
     });
 
 });
 
 describe('The grid dataSource reducer saveRow func', () => {
+    beforeEach(() => resetLastUpdate());
 
     const inState = fromJS({
         'test-grid': {
@@ -321,7 +341,8 @@ describe('The grid dataSource reducer saveRow func', () => {
                 { cell: 1 },
                 { cell: 2 }
             ],
-            total: 2
+            total: 2,
+            lastUpdate: 1
         }
     });
 
@@ -341,7 +362,8 @@ describe('The grid dataSource reducer saveRow func', () => {
                     { cell: 'newValues' },
                     { cell: 2 }
                 ],
-                total: 2
+                total: 2,
+                lastUpdate: 1
             }
         });
 
@@ -354,13 +376,14 @@ describe('The grid dataSource reducer saveRow func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
 
     });
 
 });
 
 describe('The grid dataSource reducer sortData func', () => {
+    beforeEach(() => resetLastUpdate());
 
     const inState = fromJS({
         'test-grid': {
@@ -376,7 +399,8 @@ describe('The grid dataSource reducer sortData func', () => {
                 { cell: 1 },
                 { cell: 2 }
             ],
-            total: 2
+            total: 2,
+            lastUpdate: 1
         }
     });
 
@@ -396,7 +420,8 @@ describe('The grid dataSource reducer sortData func', () => {
                     { cell: 1 },
                     { cell: 2 }
                 ],
-                total: 2
+                total: 2,
+                lastUpdate: 1
             }
         });
 
@@ -411,13 +436,14 @@ describe('The grid dataSource reducer sortData func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
 
     });
 
 });
 
 describe('The grid dataSource reducer clearFilter func', () => {
+    beforeEach(() => resetLastUpdate());
 
     const inState = fromJS({
         'test-grid': {
@@ -433,7 +459,8 @@ describe('The grid dataSource reducer clearFilter func', () => {
                 { cell: 2 },
                 { cell: 1 }
             ],
-            total: 2
+            total: 2,
+            lastUpdate: 1
         }
     });
 
@@ -453,7 +480,8 @@ describe('The grid dataSource reducer clearFilter func', () => {
                     { cell: 1 },
                     { cell: 2 }
                 ],
-                total: 2
+                total: 2,
+                lastUpdate: 1
             }
         });
 
@@ -464,13 +492,14 @@ describe('The grid dataSource reducer clearFilter func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
 
     });
 
 });
 
 describe('The grid dataSource reducer filterData func', () => {
+    beforeEach(() => resetLastUpdate());
 
     const inState = fromJS({
         'test-grid': {
@@ -486,7 +515,8 @@ describe('The grid dataSource reducer filterData func', () => {
                 { cell: 1 },
                 { cell: 2 }
             ],
-            total: 2
+            total: 2,
+            lastUpdate: 1
         }
     });
 
@@ -506,7 +536,8 @@ describe('The grid dataSource reducer filterData func', () => {
                     { cell: 1 },
                     { cell: 2 }
                 ],
-                total: 2
+                total: 2,
+                lastUpdate: 1
             }
         });
 
@@ -521,7 +552,7 @@ describe('The grid dataSource reducer filterData func', () => {
 
         expect(
             dataSource(inState, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
 
     });
 

--- a/test/reducers/components/grid.test.js
+++ b/test/reducers/components/grid.test.js
@@ -12,6 +12,10 @@ import
     grid
 from './../../../src/reducers/components/grid';
 
+import {
+    resetLastUpdate
+} from './../../../src/util/lastUpdate';
+
 const columns = [
     {
         name: 'col1',
@@ -25,6 +29,7 @@ const columns = [
 ];
 
 describe('The grid reducer setCol func', () => {
+    beforeEach(() => resetLastUpdate());
 
     const state = fromJS({});
 
@@ -36,19 +41,22 @@ describe('The grid reducer setCol func', () => {
 
     const outState = fromJS({
         'test-grid': {
-            columns
+            columns,
+            lastUpdate: 1
         }
     });
 
     it('Should set passing cols', () => {
         expect(
             grid(state, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
     });
 
 });
 
 describe('The grid reducer SET_SORT_DIRECTION func', () => {
+    beforeEach(() => resetLastUpdate());
+
     const state = fromJS({});
 
     const action = {
@@ -59,18 +67,21 @@ describe('The grid reducer SET_SORT_DIRECTION func', () => {
 
     const outState = fromJS({
         'test-grid': {
-            columns
+            columns,
+            lastUpdate: 1
         }
     });
 
     it('Should set cols after sort action', () => {
         expect(
             grid(state, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
     });
 });
 
 describe('The grid reducer resizeCols func', () => {
+    beforeEach(() => resetLastUpdate());
+
     const state = fromJS({});
 
     const action = {
@@ -81,14 +92,15 @@ describe('The grid reducer resizeCols func', () => {
 
     const outState = fromJS({
         'test-grid': {
-            columns
+            columns,
+            lastUpdate: 1
         }
     });
 
     it('Should set cols after resize action', () => {
         expect(
             grid(state, action)
-        ).toEqual(outState);
+        ).toEqualImmutable(outState);
     });
 
 });

--- a/test/reducers/components/plugins/bulkaction.test.js
+++ b/test/reducers/components/plugins/bulkaction.test.js
@@ -10,7 +10,13 @@ import
     bulkaction
 from './../../../../src/reducers/components/plugins/bulkaction';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The bulkaction reducer', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should set toolbar as visible', () => {
 
@@ -31,7 +37,8 @@ describe('The bulkaction reducer', () => {
         ).toEqual(
             fromJS({
                 'test-grid': {
-                    isRemoved: false
+                    isRemoved: false,
+                    lastUpdate: 1
                 }
             })
         );
@@ -57,7 +64,8 @@ describe('The bulkaction reducer', () => {
         ).toEqual(
             fromJS({
                 'test-grid': {
-                    isRemoved: true
+                    isRemoved: true,
+                    lastUpdate: 1
                 }
             })
         );

--- a/test/reducers/components/plugins/editor.test.js
+++ b/test/reducers/components/plugins/editor.test.js
@@ -15,6 +15,11 @@ import
     { isCellValid, isRowValid }
 from './../../../../src/reducers/components/plugins/editor';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The editor reducer isCellValid func', () => {
 
     it('Should use a validator if avail', () => {
@@ -151,6 +156,7 @@ describe('The editor reducer isRowValid func', () => {
 });
 
 describe('The editor reducer EDIT_ROW action', () => {
+    beforeEach(() => resetLastUpdate());
 
     const state = fromJS({});
 
@@ -183,7 +189,7 @@ describe('The editor reducer EDIT_ROW action', () => {
 
         expect(
             editor(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 row: {
                     key: 'rowid-2',
@@ -195,7 +201,8 @@ describe('The editor reducer EDIT_ROW action', () => {
                     top: 30,
                     valid: true,
                     isCreate: false
-                }
+                },
+                lastUpdate: 1
             }
         }));
     });
@@ -230,7 +237,7 @@ describe('The editor reducer EDIT_ROW action', () => {
 
         expect(
             editor(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 row: {
                     key: 'rowid-2',
@@ -242,7 +249,8 @@ describe('The editor reducer EDIT_ROW action', () => {
                     top: 30,
                     valid: false,
                     isCreate: true
-                }
+                },
+                lastUpdate: 1
             }
         }));
 
@@ -251,6 +259,7 @@ describe('The editor reducer EDIT_ROW action', () => {
 });
 
 describe('The editor reducer ROW_VALUE_CHANGE action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should return the correct rowValue change response', () => {
 
@@ -298,7 +307,7 @@ describe('The editor reducer ROW_VALUE_CHANGE action', () => {
 
         expect(
             editor(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 row: {
                     key: 'rowid-2',
@@ -314,7 +323,8 @@ describe('The editor reducer ROW_VALUE_CHANGE action', () => {
                         col1: NaN,
                         col2: NaN
                     }
-                }
+                },
+                lastUpdate: 1
             }
         }));
 
@@ -326,6 +336,7 @@ describe([
     'The editor reducer REMOVE_ROW action, ',
     'The editor reducer DISMISS_EDITOR action, ',
     'The editor reducer CANCEL_ROW action'].join(''), () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should wipe the values upon remove', () => {
 
@@ -352,8 +363,8 @@ describe([
 
         expect(
             editor(state, action)
-        ).toEqual(fromJS({
-            'test-grid': {}
+        ).toEqualImmutable(fromJS({
+            'test-grid': { lastUpdate: 1 }
         }));
     });
 
@@ -382,8 +393,8 @@ describe([
 
         expect(
             editor(state, action)
-        ).toEqual(fromJS({
-            'test-grid': {}
+        ).toEqualImmutable(fromJS({
+            'test-grid': { lastUpdate: 1}
         }));
     });
 
@@ -412,8 +423,8 @@ describe([
 
         expect(
             editor(state, action)
-        ).toEqual(fromJS({
-            'test-grid': {}
+        ).toEqualImmutable(fromJS({
+            'test-grid': { lastUpdate: 1 }
         }));
     });
 

--- a/test/reducers/components/plugins/errorhandler.test.js
+++ b/test/reducers/components/plugins/errorhandler.test.js
@@ -11,7 +11,13 @@ import
     errorhandler
 from './../../../../src/reducers/components/plugins/errorhandler';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The errorhandler reducer', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should set an error if state was blank', () => {
 
@@ -25,10 +31,11 @@ describe('The errorhandler reducer', () => {
 
         expect(
             errorhandler(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 error: 'A generic error occurred dude',
-                errorOccurred: true
+                errorOccurred: true,
+                lastUpdate: 1
             }
         }));
 
@@ -51,10 +58,11 @@ describe('The errorhandler reducer', () => {
 
         expect(
             errorhandler(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 error: 'A newer error happened',
-                errorOccurred: true
+                errorOccurred: true,
+                lastUpdate: 1
             }
         }));
 
@@ -65,7 +73,8 @@ describe('The errorhandler reducer', () => {
         const state = fromJS({
             'test-grid': {
                 error: 'A generic error occurred dude',
-                errorOccurred: true
+                errorOccurred: true,
+                lastUpdate: 1
             }
         });
 
@@ -76,10 +85,11 @@ describe('The errorhandler reducer', () => {
 
         expect(
             errorhandler(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 error: '',
-                errorOccurred: false
+                errorOccurred: false,
+                lastUpdate: 1
             }
         }));
 

--- a/test/reducers/components/plugins/filter.test.js
+++ b/test/reducers/components/plugins/filter.test.js
@@ -12,7 +12,13 @@ import
     filter
 from './../../../../src/reducers/components/plugins/filter';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The filter reducer SET_FILTER_VALUE action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should set a filter value, maintaining previous reducer state', () => {
 
@@ -32,12 +38,13 @@ describe('The filter reducer SET_FILTER_VALUE action', () => {
 
         expect(
             filter(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 filterMenuShown: true,
                 filterValue: {
                     someProp: 'filtering on prop'
-                }
+                },
+                lastUpdate: 1
             }
         }));
 
@@ -46,6 +53,7 @@ describe('The filter reducer SET_FILTER_VALUE action', () => {
 });
 
 describe('The filter reducer SHOW_FILTER_MENU action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should show filter menu, wiping previous state', () => {
 
@@ -66,9 +74,10 @@ describe('The filter reducer SHOW_FILTER_MENU action', () => {
 
         expect(
             filter(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
-                filterMenuShown: true
+                filterMenuShown: true,
+                lastUpdate: 1
             }
         }));
 
@@ -77,6 +86,7 @@ describe('The filter reducer SHOW_FILTER_MENU action', () => {
 });
 
 describe('The filter reducer SET_FILTER_MENU_VALUES action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should show filter menu, merging new filter vals with old', () => {
 
@@ -100,13 +110,14 @@ describe('The filter reducer SET_FILTER_MENU_VALUES action', () => {
 
         expect(
             filter(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 filterMenuShown: true,
                 filterMenuValues: {
                     someProp: 1,
                     newProp: 'newVal'
-                }
+                },
+                lastUpdate: 1
             }
         }));
 
@@ -126,12 +137,13 @@ describe('The filter reducer SET_FILTER_MENU_VALUES action', () => {
 
         expect(
             filter(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
                 filterMenuValues: {
                     newProp: 'newVal'
                 },
-                filterMenuShown: true
+                filterMenuShown: true,
+                lastUpdate: 1
             }
         }));
 

--- a/test/reducers/components/plugins/loader.test.js
+++ b/test/reducers/components/plugins/loader.test.js
@@ -10,7 +10,13 @@ import
     loader
 from './../../../../src/reducers/components/plugins/loader';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The loader reducer SET_LOADING_STATE action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should set loading to true', () => {
 
@@ -24,8 +30,11 @@ describe('The loader reducer SET_LOADING_STATE action', () => {
 
         expect(
             loader(state, action)
-        ).toEqual(fromJS({
-            'test-grid': true
+        ).toEqualImmutable(fromJS({
+            'test-grid': {
+                isLoading: true,
+                lastUpdate: 1
+            }
         }));
 
     });
@@ -42,8 +51,11 @@ describe('The loader reducer SET_LOADING_STATE action', () => {
 
         expect(
             loader(state, action)
-        ).toEqual(fromJS({
-            'test-grid': false
+        ).toEqualImmutable(fromJS({
+            'test-grid': {
+                isLoading: false,
+                lastUpdate: 1
+            }
         }));
 
     });

--- a/test/reducers/components/plugins/menu.test.js
+++ b/test/reducers/components/plugins/menu.test.js
@@ -11,7 +11,13 @@ import
     menu
 from './../../../../src/reducers/components/plugins/menu';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The menu reducer SHOW_MENU action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should show a menu, hiding the previously opened menu', () => {
 
@@ -29,9 +35,10 @@ describe('The menu reducer SHOW_MENU action', () => {
 
         expect(
             menu(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
-                newId: true
+                newId: true,
+                lastUpdate: 1
             }
         }));
 
@@ -49,9 +56,10 @@ describe('The menu reducer SHOW_MENU action', () => {
 
         expect(
             menu(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
-                newId: true
+                newId: true,
+                lastUpdate: 1
             }
         }));
 
@@ -60,6 +68,7 @@ describe('The menu reducer SHOW_MENU action', () => {
 });
 
 describe('The menu reducer HIDE_MENU action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should hide a menu, also hiding the previously opened menu', () => {
 
@@ -77,9 +86,10 @@ describe('The menu reducer HIDE_MENU action', () => {
 
         expect(
             menu(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
-                newId: false
+                newId: false,
+                lastUpdate: 1
             }
         }));
 
@@ -97,9 +107,10 @@ describe('The menu reducer HIDE_MENU action', () => {
 
         expect(
             menu(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
-                newId: false
+                newId: false,
+                lastUpdate: 1
             }
         }));
 

--- a/test/reducers/components/plugins/pager.test.js
+++ b/test/reducers/components/plugins/pager.test.js
@@ -11,7 +11,13 @@ import
     pager
 from './../../../../src/reducers/components/plugins/pager';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The pager reducer PAGE_LOCAL action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should set pageIndex locally', () => {
 
@@ -25,9 +31,10 @@ describe('The pager reducer PAGE_LOCAL action', () => {
 
         expect(
             pager(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
-                pageIndex: 26
+                pageIndex: 26,
+                lastUpdate: 1
             }
         }));
 
@@ -36,6 +43,7 @@ describe('The pager reducer PAGE_LOCAL action', () => {
 });
 
 describe('The pager reducer PAGE_REMOTE action', () => {
+    beforeEach(() => resetLastUpdate());
 
     it('Should set pageIndex locally', () => {
 
@@ -49,9 +57,10 @@ describe('The pager reducer PAGE_REMOTE action', () => {
 
         expect(
             pager(state, action)
-        ).toEqual(fromJS({
+        ).toEqualImmutable(fromJS({
             'test-grid': {
-                pageIndex: 19
+                pageIndex: 19,
+                lastUpdate: 1
             }
         }));
 

--- a/test/reducers/components/plugins/selection.test.js
+++ b/test/reducers/components/plugins/selection.test.js
@@ -12,7 +12,13 @@ import
     selection
 from './../../../../src/reducers/components/plugins/selection';
 
+import {
+    generateLastUpdate,
+    resetLastUpdate
+} from './../../../../src/util/lastUpdate';
+
 describe('The selectAll func in the selection reducer', () => {
+    beforeEach(() => resetLastUpdate());
 
     const state = fromJS({
         'test-grid': {
@@ -33,11 +39,12 @@ describe('The selectAll func in the selection reducer', () => {
     it('Should return all rows as selected', () => {
         expect(
             selection(state, action)
-        ).toEqual(
+        ).toEqualImmutable(
             fromJS({
                 'test-grid': {
                     fakeRow: true,
-                    anotherRow: true
+                    anotherRow: true,
+                    lastUpdate: 1
                 }
             })
         );
@@ -46,6 +53,7 @@ describe('The selectAll func in the selection reducer', () => {
 });
 
 describe('The deselectAll func in the selection reducer', () => {
+    beforeEach(() => resetLastUpdate());
 
     const state = fromJS({
         'test-grid': {
@@ -62,9 +70,9 @@ describe('The deselectAll func in the selection reducer', () => {
     it('Should return an empty map upon deselect', () => {
         expect(
             selection(state, action)
-        ).toEqual(
+        ).toEqualImmutable(
             fromJS({
-                'test-grid': {}
+                'test-grid': { lastUpdate: 1 }
             })
         );
     });
@@ -72,6 +80,7 @@ describe('The deselectAll func in the selection reducer', () => {
 });
 
 describe('The setSelection func in the selection reducer', () => {
+    beforeEach(() => resetLastUpdate());
 
     const state = fromJS({
         'test-grid': {
@@ -92,10 +101,11 @@ describe('The setSelection func in the selection reducer', () => {
 
         expect(
             selection(state, action)
-        ).toEqual(
+        ).toEqualImmutable(
             fromJS({
                 'test-grid': {
-                    anotherRow: true
+                    anotherRow: true,
+                    lastUpdate: 1
                 }
             })
         );
@@ -114,10 +124,11 @@ describe('The setSelection func in the selection reducer', () => {
 
         expect(
             selection(state, action)
-        ).toEqual(
+        ).toEqualImmutable(
             fromJS({
                 'test-grid': {
-                    fakeRow: false
+                    fakeRow: false,
+                    lastUpdate: 1
                 }
             })
         );
@@ -135,10 +146,11 @@ describe('The setSelection func in the selection reducer', () => {
 
         expect(
             selection(innerState, action)
-        ).toEqual(
+        ).toEqualImmutable(
             fromJS({
                 'test-grid': {
-                    fakeRow: true
+                    fakeRow: true,
+                    lastUpdate: 1
                 }
             })
         );
@@ -161,11 +173,12 @@ describe('The setSelection func in the selection reducer', () => {
 
         expect(
             selection(selectedState, action)
-        ).toEqual(
+        ).toEqualImmutable(
             fromJS({
                 'test-grid': {
                     fakeRow: true,
-                    anotherRow: true
+                    anotherRow: true,
+                    lastUpdate: 1
                 }
             })
         );

--- a/test/util/lastUpdate.test.js
+++ b/test/util/lastUpdate.test.js
@@ -1,0 +1,83 @@
+import expect from 'expect';
+import { fromJS } from 'immutable';
+
+import {
+    generateLastUpdate,
+    getLastUpdate,
+    resetLastUpdate
+} from './../../src/util/lastUpdate';
+
+describe('LastUpdate utility', () => {
+
+    it('Should generateLastUpdate with a incrementing number', () => {
+        const first = generateLastUpdate();
+        const second = generateLastUpdate();
+
+        expect(
+            first
+        ).toBeA('number');
+
+        expect(
+            second
+        ).toBeA('number');
+
+        expect(
+            first < second
+        ).toBe(true);
+    });
+
+    it('Should resetLastUdate where next generate will return 1', () => {
+        resetLastUpdate();
+
+        expect(
+            generateLastUpdate()
+        ).toBe(1);
+
+        expect(
+            generateLastUpdate()
+        ).toBe(2);
+
+        resetLastUpdate();
+
+        expect(
+            generateLastUpdate()
+        ).toBe(1);
+
+        expect(
+            generateLastUpdate()
+        ).toBe(2);
+    });
+
+    it('Should getLastupdate and provide a map of reducers lastUpdate', () => {
+        const store = {
+            getState: () => ({
+                bulkaction: fromJS({ 'test-grid-1': { lastUpdate: 1 } }),
+                dataSource: fromJS({ 'test-grid-1': { lastUpdate: 2 } }),
+                editor: fromJS({ 'test-grid-1': { lastUpdate: 3 } }),
+                errorhandler: fromJS({ 'test-grid-1': { lastUpdate: 4 } }),
+                filter: fromJS({ 'test-grid-1': { lastUpdate: 5 } }),
+                grid: fromJS({ 'test-grid-1': { lastUpdate: 6 } }),
+                loader: fromJS({ 'test-grid-1': { lastUpdate: 7 } }),
+                menu: fromJS({ 'test-grid-1': { lastUpdate: 8 } }),
+                pager: fromJS({ 'test-grid-1': { lastUpdate: 9 } }),
+                selection: fromJS({ 'test-grid-1': { lastUpdate: 10 } })
+            })
+        };
+
+        expect(
+            getLastUpdate(store, 'test-grid-1')
+        ).toEqual({
+            bulkaction: 1,
+            dataSource: 2,
+            editor: 3,
+            errorhandler: 4,
+            filter: 5,
+            grid: 6,
+            loader: 7,
+            menu: 8,
+            pager: 9,
+            selection: 10
+        });
+    });
+
+});

--- a/test/util/shouldComponentUpdate.test.js
+++ b/test/util/shouldComponentUpdate.test.js
@@ -15,6 +15,7 @@ describe('shouldGridUpdate utility function', () => {
     component.props.store = store;
 
     const nextProps = {
+        classNames: ['blurg'],
         columns: [
             {
                 name: 'col1',
@@ -45,28 +46,13 @@ describe('shouldGridUpdate utility function', () => {
 
         const alteredNextProps = {
             ...nextProps,
-            menuState: false
+            classNames: ['food']
         };
 
         expect(
            shouldGridUpdate.call(component, alteredNextProps)
         ).toEqual(
             true
-        );
-
-    });
-
-    it('return true if props have changed', () => {
-
-        const alteredNextProps = {
-            ...nextProps,
-            menuState: false
-        };
-
-        expect(
-           shouldGridUpdate.call(component, alteredNextProps)
-        ).toEqual(
-            false
         );
 
     });


### PR DESCRIPTION
### Added
- [`deep-equal` dependency](https://www.npmjs.com/package/deep-equal). Used in `shouldUpdateComponent` for deep object equality comparison.
- `$ npm run test-watch` will now continually watch for file changes and re-run tests.
- `$ npm run lint` will now run through all your lint errors
- `lastUpdate` utility collection to generate unique numerical keys to stamp state.

### Changed
- Grid's `shouldComponentUpdate` no longer runs through mapStateToProps and then running an equality check on state.
- All reducers now have a `lastUpdate` property at the reducer key + state key level. Each action handled by the reducer will now update this property. This is used as a comparison key in `shouldComponentUpdate` on grid to determine quickly if state has changed.