### PR TITLE
add stateful manager, add stateful args to all col actions, update tests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -172,6 +172,18 @@ const dataSource = () => {
 const grid = <Grid dataSource= { dataSource } />
  ```
 
+## Grid Level Parameters
+
+1. `stateful`: `bool`, if `stateful` is `true`, the grid will store column configuration in browser local storage (based off of `stateKey`, so the key must be unique across all grids in a single application)
+2. `height`: `number`, the height of the grid container
+3. `showTreeRootNode`: `bool`, used with tree-grid, to determine if root node should be displaued
+4. `classNames`: `array`, a list of strings to be applied to the grid container as classes
+5. `events`: `object`, more information below
+6. `store`: `object.isRequired`
+7. `reducerKeys`: `object`, more information below
+8. `pageSize`: `number`, the number of records to show on the grid
+
+
 ## Plugins
 
 All Features are implemented as plugins. Plugin defaults are described as below. Their default values can be modified, and new plugins can be introduced with very little modification to core components.

--- a/demo/demoData.js
+++ b/demo/demoData.js
@@ -9,6 +9,8 @@ export const stateKey = 'grid-stateKey';
 
 export const height = '';
 
+export const stateful = true;
+
 export const events = {
     HANDLE_CELL_CLICK: (cell, reactEvent, id, browserEvent) => {
         console.log('On Cell Click Event');
@@ -138,12 +140,6 @@ export const columns = [
         className: 'additional-class',
         expandable: true,
         HANDLE_CLICK: () => { console.log('Header Click'); }
-    },
-    {
-        name: 'GUID',
-        dataIndex: 'GUID',
-        hidden: true,
-        createKeyFrom: true
     },
     {
         name: 'Phone Number',

--- a/demo/provider.jsx
+++ b/demo/provider.jsx
@@ -14,6 +14,7 @@ import {
     events,
     dataSource,
     treeDataSource,
+    stateful,
     height,
     stateKey,
     treeData
@@ -23,6 +24,7 @@ const config = {
     columns,
     // data: treeData,
     // dataSource: treeDataSource,
+    stateful,
     dataSource,
     // gridType: 'tree',
     pageSize,

--- a/dist/actions/GridActions.js
+++ b/dist/actions/GridActions.js
@@ -169,6 +169,7 @@ function getAsyncData(_ref) {
 function setColumns(_ref2) {
     var columns = _ref2.columns;
     var stateKey = _ref2.stateKey;
+    var stateful = _ref2.stateful;
 
 
     var cols = columns;
@@ -180,7 +181,7 @@ function setColumns(_ref2) {
         });
     }
 
-    return { type: _ActionTypes.SET_COLUMNS, columns: cols, stateKey: stateKey };
+    return { type: _ActionTypes.SET_COLUMNS, columns: cols, stateKey: stateKey, stateful: stateful };
 }
 
 function setSortDirection(_ref3) {
@@ -298,6 +299,7 @@ function setColumnVisibility(_ref6) {
     var column = _ref6.column;
     var isHidden = _ref6.isHidden;
     var stateKey = _ref6.stateKey;
+    var stateful = _ref6.stateful;
 
     var hidden = !isHidden;
 
@@ -309,7 +311,7 @@ function setColumnVisibility(_ref6) {
         return col;
     });
 
-    return { type: _ActionTypes.SET_COLUMNS, columns: columnsArr, stateKey: stateKey };
+    return { type: _ActionTypes.SET_COLUMNS, columns: columnsArr, stateKey: stateKey, stateful: stateful };
 }
 
 function resizeColumns(_ref7) {
@@ -318,6 +320,7 @@ function resizeColumns(_ref7) {
     var nextColumn = _ref7.nextColumn;
     var columns = _ref7.columns;
     var stateKey = _ref7.stateKey;
+    var stateful = _ref7.stateful;
 
 
     var cols = columns.map(function (col) {
@@ -334,7 +337,8 @@ function resizeColumns(_ref7) {
     return {
         type: _ActionTypes.RESIZE_COLUMNS,
         stateKey: stateKey,
-        columns: cols
+        columns: cols,
+        stateful: stateful
     };
 }
 

--- a/dist/actions/core/ColumnManager.js
+++ b/dist/actions/core/ColumnManager.js
@@ -12,6 +12,7 @@ var reorderColumn = exports.reorderColumn = function reorderColumn(_ref) {
     var droppedIndex = _ref.droppedIndex;
     var columns = _ref.columns;
     var stateKey = _ref.stateKey;
+    var stateful = _ref.stateful;
 
 
     var reorder = function reorder(cols, to, from) {
@@ -24,6 +25,7 @@ var reorderColumn = exports.reorderColumn = function reorderColumn(_ref) {
     return {
         type: _ActionTypes.SET_COLUMNS,
         columns: reorderedColumns,
-        stateKey: stateKey
+        stateKey: stateKey,
+        stateful: stateful
     };
 };

--- a/dist/components/Grid.js
+++ b/dist/components/Grid.js
@@ -67,6 +67,10 @@ var _shouldComponentUpdate = require('../util/shouldComponentUpdate');
 
 var _isPluginEnabled = require('../util/isPluginEnabled');
 
+var _LocalStorageManager = require('./core/LocalStorageManager');
+
+var _LocalStorageManager2 = _interopRequireDefault(_LocalStorageManager);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return (0, _arrayFrom2.default)(arr); } }
@@ -112,6 +116,7 @@ var Grid = function (_Component) {
             var pager = _props.pager;
             var editorState = _props.editorState;
             var selectedRows = _props.selectedRows;
+            var stateful = _props.stateful;
             var menuState = _props.menuState;
             var showTreeRootNode = _props.showTreeRootNode;
 
@@ -151,6 +156,7 @@ var Grid = function (_Component) {
                 selectionModel: this.selectionModel,
                 stateKey: stateKey,
                 store: store,
+                stateful: stateful,
                 visible: false,
                 menuState: menuState,
                 gridType: this.gridType
@@ -346,12 +352,18 @@ var Grid = function (_Component) {
             var columns = _props4.columns;
             var stateKey = _props4.stateKey;
             var store = _props4.store;
+            var stateful = _props4.stateful;
 
+            var savedColumns = columns;
+
+            if (stateful) {
+                savedColumns = _LocalStorageManager2.default.getStateItem({ stateKey: stateKey, value: columns, property: 'columns' });
+            }
 
             if (!columns) {
                 throw new Error('A columns array is required');
             } else {
-                store.dispatch((0, _GridActions.setColumns)({ columns: columns, stateKey: stateKey }));
+                store.dispatch((0, _GridActions.setColumns)({ columns: savedColumns, stateKey: stateKey, stateful: stateful }));
             }
         }
     }]);
@@ -380,6 +392,7 @@ Grid.propTypes = {
     selectedRows: object,
     showTreeRootNode: bool,
     stateKey: string,
+    stateful: bool,
     store: object
 };
 Grid.defaultProps = {

--- a/dist/components/core/ColumnManager.js
+++ b/dist/components/core/ColumnManager.js
@@ -139,6 +139,7 @@ var ColumnManager = function () {
             var rowIndex = _ref3.rowIndex;
             var menuState = _ref3.menuState;
             var stateKey = _ref3.stateKey;
+            var stateful = _ref3.stateful;
             var GRID_ACTIONS = this.plugins.GRID_ACTIONS;
 
             var cellsCopy = cells;
@@ -153,6 +154,7 @@ var ColumnManager = function () {
                 editor: this.editor,
                 reducerKeys: reducerKeys,
                 selModel: this.selModel,
+                stateful: stateful,
                 stateKey: stateKey,
                 menuState: menuState,
                 gridState: columns,

--- a/dist/components/core/LocalStorageManager.js
+++ b/dist/components/core/LocalStorageManager.js
@@ -1,0 +1,76 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.LocalStorageManager = undefined;
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _throttle = require('./../../util/throttle');
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var LocalStorageManager = exports.LocalStorageManager = function () {
+    function LocalStorageManager() {
+        _classCallCheck(this, LocalStorageManager);
+    }
+
+    _createClass(LocalStorageManager, [{
+        key: 'setStateItem',
+        value: function setStateItem(_ref) {
+            var stateKey = _ref.stateKey;
+            var property = _ref.property;
+            var value = _ref.value;
+
+
+            var json = JSON.stringify(value);
+
+            window.localStorage.setItem(this.getKey({ stateKey: stateKey, property: property }), json);
+        }
+    }, {
+        key: 'debouncedSetStateItem',
+        value: function debouncedSetStateItem() {
+            return (0, _throttle.debounce)(this.setStateItem.bind(this), 500, false);
+        }
+    }, {
+        key: 'getStateItem',
+        value: function getStateItem(_ref2) {
+            var stateKey = _ref2.stateKey;
+            var property = _ref2.property;
+            var value = _ref2.value;
+            var _ref2$shouldSave = _ref2.shouldSave;
+            var shouldSave = _ref2$shouldSave === undefined ? true : _ref2$shouldSave;
+
+
+            var item = window.localStorage.getItem(this.getKey({ stateKey: stateKey, property: property }));
+
+            if (item) {
+                return JSON.parse(item);
+            }
+
+            if (value && shouldSave) {
+                this.setStateItem({ stateKey: stateKey, property: property, value: value });
+            }
+
+            return value;
+        }
+    }, {
+        key: 'getKey',
+        value: function getKey(_ref3) {
+            var stateKey = _ref3.stateKey;
+            var property = _ref3.property;
+
+
+            if (!stateKey || !property) {
+                throw new Error('stateKey and property are required params');
+            }
+
+            return 'react-grid-' + stateKey + '-' + property;
+        }
+    }]);
+
+    return LocalStorageManager;
+}();
+
+exports.default = new LocalStorageManager();

--- a/dist/components/layout/FixedHeader.js
+++ b/dist/components/layout/FixedHeader.js
@@ -42,6 +42,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var arrayOf = _react.PropTypes.arrayOf;
+var bool = _react.PropTypes.bool;
 var object = _react.PropTypes.object;
 var string = _react.PropTypes.string;
 
@@ -64,6 +65,7 @@ var FixedHeader = function (_Component) {
             var reducerKeys = _props.reducerKeys;
             var selectionModel = _props.selectionModel;
             var stateKey = _props.stateKey;
+            var stateful = _props.stateful;
             var store = _props.store;
             var pager = _props.pager;
             var plugins = _props.plugins;
@@ -93,6 +95,7 @@ var FixedHeader = function (_Component) {
                     pager: pager,
                     store: store,
                     stateKey: stateKey,
+                    stateful: stateful,
                     visibleColumns: visibleColumns,
                     key: 'fixed-header-' + i
                 };
@@ -148,6 +151,7 @@ var FixedHeader = function (_Component) {
                 id: 'header-row',
                 reducerKeys: reducerKeys,
                 stateKey: stateKey,
+                stateful: stateful,
                 menuState: menuState
             });
 
@@ -358,6 +362,7 @@ FixedHeader.propTypes = {
     reducerKeys: object,
     selectionModel: object,
     stateKey: string,
+    stateful: bool,
     store: object
 };
 var addEmptyInsert = exports.addEmptyInsert = function addEmptyInsert(headers, visibleColumns, plugins, headerOffset) {
@@ -386,7 +391,7 @@ var addEmptyInsert = exports.addEmptyInsert = function addEmptyInsert(headers, v
     }
 };
 
-var handleDrag = exports.handleDrag = function handleDrag(scope, columns, id, columnManager, store, nextColumnKey, stateKey, reactEvent) {
+var handleDrag = exports.handleDrag = function handleDrag(scope, columns, id, columnManager, store, nextColumnKey, stateKey, stateful, reactEvent) {
 
     var header = reactEvent.target.parentElement.parentElement;
     var columnNode = reactEvent.target.parentElement;
@@ -425,7 +430,8 @@ var handleDrag = exports.handleDrag = function handleDrag(scope, columns, id, co
             width: nextColWidth
         },
         columns: columns,
-        stateKey: stateKey
+        stateKey: stateKey,
+        stateful: stateful
     }));
 };
 

--- a/dist/components/layout/header/Column.js
+++ b/dist/components/layout/header/Column.js
@@ -41,6 +41,7 @@ var Column = exports.Column = function Column(_ref) {
     var store = _ref.store;
     var stateKey = _ref.stateKey;
     var index = _ref.index;
+    var stateful = _ref.stateful;
 
 
     if (col.hidden) {
@@ -63,7 +64,7 @@ var Column = exports.Column = function Column(_ref) {
 
     var nextColumnKey = visibleColumns && visibleColumns[index + 1] ? (0, _keyGenerator.keyGenerator)(visibleColumns[index + 1].name, 'grid-column') : null;
 
-    var handleDrag = scope.handleDrag.bind(scope, scope, columns, key, columnManager, store, nextColumnKey, stateKey);
+    var handleDrag = scope.handleDrag.bind(scope, scope, columns, key, columnManager, store, nextColumnKey, stateKey, stateful);
 
     var sortHandle = sortable ? _react2.default.createElement(_SortHandle.SortHandle, {
         col: col,
@@ -101,7 +102,7 @@ var Column = exports.Column = function Column(_ref) {
     var headerProps = {
         className: headerClass,
         onClick: handleColumnClick.bind(scope, clickArgs),
-        onDrop: handleDrop.bind(scope, index, columns, stateKey, store),
+        onDrop: handleDrop.bind(scope, index, columns, stateful, stateKey, store),
         onDragOver: function onDragOver(reactEvent) {
             reactEvent.preventDefault();
         },
@@ -115,17 +116,20 @@ var Column = exports.Column = function Column(_ref) {
         headerProps.onDragOver = function (reactEvent) {
             // due to a bug in firefox, we need to set a global to
             // preserve the x coords
-            // http://stackoverflow.com/questions/11656061/event-clientx-showing-as-0-in-firefox-for-dragend-event
+            // http://stackoverflow.com/questions/11656061/
+            // event-clientx-showing-as-0-in-firefox-for-dragend-event
             window.reactGridXcoord = reactEvent.clientX;
             reactEvent.preventDefault();
         };
     }
 
-    var innerHTML = _react2.default.createElement(_Text.Text, { col: col,
+    var innerHTML = _react2.default.createElement(_Text.Text, {
+        col: col,
         index: index,
         columnManager: columnManager,
         dragAndDropManager: dragAndDropManager,
-        sortHandle: sortHandle });
+        sortHandle: sortHandle
+    });
 
     return _react2.default.createElement(
         'th',
@@ -145,10 +149,11 @@ Column.propTypes = {
     pager: _react.PropTypes.object,
     scope: _react.PropTypes.object,
     stateKey: _react.PropTypes.string,
+    stateful: _react.PropTypes.bool,
     store: _react.PropTypes.object
 };
 
-var handleDrop = exports.handleDrop = function handleDrop(droppedIndex, columns, stateKey, store, reactEvent) {
+var handleDrop = exports.handleDrop = function handleDrop(droppedIndex, columns, stateful, stateKey, store, reactEvent) {
 
     reactEvent.preventDefault();
     try {
@@ -159,11 +164,14 @@ var handleDrop = exports.handleDrop = function handleDrop(droppedIndex, columns,
                 draggedIndex: colData.index,
                 droppedIndex: droppedIndex,
                 columns: columns,
-                stateKey: stateKey
+                stateKey: stateKey,
+                stateful: stateful
             }));
         }
     } catch (e) {
+        /* eslint-disable no-console */
         console.warn('Invalid drop');
+        /* eslint-enable no-console */
     }
 };
 

--- a/dist/components/plugins/gridactions/ActionColumn.js
+++ b/dist/components/plugins/gridactions/ActionColumn.js
@@ -36,6 +36,7 @@ var ActionColumn = exports.ActionColumn = function ActionColumn(_ref) {
     var rowData = _ref.rowData;
     var store = _ref.store;
     var stateKey = _ref.stateKey;
+    var stateful = _ref.stateful;
     var type = _ref.type;
     var rowIndex = _ref.rowIndex;
     var reducerKeys = _ref.reducerKeys;
@@ -56,7 +57,7 @@ var ActionColumn = exports.ActionColumn = function ActionColumn(_ref) {
         className: className
     };
 
-    return type === 'header' ? getHeader(columns, containerProps, iconProps, menuShown, columns, store, editor, reducerKeys, rowId, rowData, rowIndex, stateKey, headerActionItemBuilder) : getColumn(columns, containerProps, iconProps, menuShown, actions, store, editor, reducerKeys, rowId, rowData, rowIndex, stateKey);
+    return type === 'header' ? getHeader(columns, containerProps, iconProps, menuShown, columns, store, editor, reducerKeys, rowId, rowData, rowIndex, stateKey, stateful, headerActionItemBuilder) : getColumn(columns, containerProps, iconProps, menuShown, actions, store, editor, reducerKeys, rowId, rowData, rowIndex, stateKey);
 };
 
 ActionColumn.propTypes = {
@@ -66,6 +67,7 @@ ActionColumn.propTypes = {
     iconCls: _react.PropTypes.string,
     menuState: _react.PropTypes.object,
     rowId: _react.PropTypes.string,
+    stateful: _react.PropTypes.bool,
     store: _react.PropTypes.object,
     type: _react.PropTypes.string
 };
@@ -103,7 +105,7 @@ var enableActions = exports.enableActions = function enableActions(menuShown, ac
     return actions;
 };
 
-var getHeader = exports.getHeader = function getHeader(cols, containerProps, iconProps, menuShown, columns, store, editor, reducerKeys, rowId, rowData, rowIndex, stateKey, headerActionItemBuilder) {
+var getHeader = exports.getHeader = function getHeader(cols, containerProps, iconProps, menuShown, columns, store, editor, reducerKeys, rowId, rowData, rowIndex, stateKey, stateful, headerActionItemBuilder) {
 
     var actions = void 0;
 
@@ -127,7 +129,8 @@ var getHeader = exports.getHeader = function getHeader(cols, containerProps, ico
                             columns: columns,
                             column: col,
                             isHidden: col.hidden,
-                            stateKey: stateKey
+                            stateKey: stateKey,
+                            stateful: stateful
                         }));
                     }
                 }

--- a/dist/reducers/components/grid.js
+++ b/dist/reducers/components/grid.js
@@ -3,15 +3,24 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
+exports.setColumnsInStorage = undefined;
 exports.default = gridState;
 
 var _immutable = require('immutable');
 
 var _ActionTypes = require('./../../constants/ActionTypes');
 
+var _LocalStorageManager = require('./../../components/core/LocalStorageManager');
+
+var _LocalStorageManager2 = _interopRequireDefault(_LocalStorageManager);
+
 var _lastUpdate = require('./../../util/lastUpdate');
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 var initialState = (0, _immutable.fromJS)({ lastUpdate: (0, _lastUpdate.generateLastUpdate)() });
+
+var debouncedColumnSetter = _LocalStorageManager2.default.debouncedSetStateItem();
 
 function gridState() {
     var state = arguments.length <= 0 || arguments[0] === undefined ? initialState : arguments[0];
@@ -27,6 +36,14 @@ function gridState() {
             }));
 
         case _ActionTypes.SET_COLUMNS:
+
+            if (action.stateful) {
+                setColumnsInStorage({
+                    stateKey: action.stateKey,
+                    columns: action.columns
+                });
+            }
+
             return state.mergeIn([action.stateKey], (0, _immutable.fromJS)({
                 columns: action.columns,
                 lastUpdate: (0, _lastUpdate.generateLastUpdate)()
@@ -39,6 +56,14 @@ function gridState() {
             }));
 
         case _ActionTypes.RESIZE_COLUMNS:
+
+            if (action.stateful) {
+                setColumnsInStorage({
+                    stateKey: action.stateKey,
+                    columns: action.columns
+                });
+            }
+
             return state.mergeIn([action.stateKey], (0, _immutable.fromJS)({
                 columns: action.columns,
                 lastUpdate: (0, _lastUpdate.generateLastUpdate)()
@@ -49,3 +74,14 @@ function gridState() {
             return state;
     }
 }
+
+var setColumnsInStorage = exports.setColumnsInStorage = function setColumnsInStorage(_ref) {
+    var columns = _ref.columns;
+    var stateKey = _ref.stateKey;
+
+    debouncedColumnSetter({
+        stateKey: stateKey,
+        property: 'columns',
+        value: columns
+    });
+};

--- a/src/actions/GridActions.js
+++ b/src/actions/GridActions.js
@@ -182,7 +182,7 @@ export function getAsyncData({
     };
 }
 
-export function setColumns({ columns, stateKey }) {
+export function setColumns({ columns, stateKey, stateful }) {
 
     let cols = columns;
 
@@ -193,7 +193,7 @@ export function setColumns({ columns, stateKey }) {
         });
     }
 
-    return { type: SET_COLUMNS, columns: cols, stateKey };
+    return { type: SET_COLUMNS, columns: cols, stateKey, stateful };
 }
 
 export function setSortDirection({
@@ -319,7 +319,9 @@ export function doRemoteSort(
     };
 }
 
-export function setColumnVisibility({ columns, column, isHidden, stateKey }) {
+export function setColumnVisibility({
+ columns, column, isHidden, stateKey, stateful
+}) {
     const hidden = !isHidden;
 
     const columnsArr = columns.map((col) => {
@@ -330,10 +332,12 @@ export function setColumnVisibility({ columns, column, isHidden, stateKey }) {
         return col;
     });
 
-    return { type: SET_COLUMNS, columns: columnsArr, stateKey };
+    return { type: SET_COLUMNS, columns: columnsArr, stateKey, stateful };
 }
 
-export function resizeColumns({ width, id, nextColumn, columns, stateKey }) {
+export function resizeColumns({
+    width, id, nextColumn, columns, stateKey, stateful
+}) {
 
     const cols = columns.map((col) => {
 
@@ -352,7 +356,8 @@ export function resizeColumns({ width, id, nextColumn, columns, stateKey }) {
     return {
         type: RESIZE_COLUMNS,
         stateKey,
-        columns: cols
+        columns: cols,
+        stateful
     };
 
 }

--- a/src/actions/core/ColumnManager.js
+++ b/src/actions/core/ColumnManager.js
@@ -3,7 +3,7 @@ import {
 } from '../../constants/ActionTypes';
 
 export const reorderColumn = ({
-    draggedIndex, droppedIndex, columns, stateKey
+    draggedIndex, droppedIndex, columns, stateKey, stateful
 }) => {
 
     const reorder = (cols, to, from) => {
@@ -16,6 +16,7 @@ export const reorderColumn = ({
     return {
         type: SET_COLUMNS,
         columns: reorderedColumns,
-        stateKey
+        stateKey,
+        stateful
     };
 };

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -23,6 +23,7 @@ import {
 import { mapStateToProps } from '../util/mapStateToProps';
 import { shouldGridUpdate } from '../util/shouldComponentUpdate';
 import { isPluginEnabled } from '../util/isPluginEnabled';
+import localStorageManager from './core/LocalStorageManager';
 
 import './../style/main.styl';
 
@@ -57,6 +58,7 @@ class Grid extends Component {
             pager,
             editorState,
             selectedRows,
+            stateful,
             menuState,
             showTreeRootNode
         } = this.props;
@@ -76,8 +78,7 @@ class Grid extends Component {
         );
 
         const containerProps = {
-            className: prefix(CLASS_NAMES.CONTAINER, ...classNames),
-            reducerKeys
+            className: prefix(CLASS_NAMES.CONTAINER, ...classNames)
         };
 
         const messageProps = {
@@ -108,6 +109,7 @@ class Grid extends Component {
             selectionModel: this.selectionModel,
             stateKey,
             store,
+            stateful,
             visible: false,
             menuState,
             gridType: this.gridType
@@ -149,9 +151,7 @@ class Grid extends Component {
 
         const tableProps = {
             className: prefix(CLASS_NAMES.TABLE, CLASS_NAMES.HEADER_HIDDEN),
-            cellSpacing: 0,
-            reducerKeys,
-            store
+            cellSpacing: 0
         };
 
         const pagerProps = {
@@ -272,6 +272,7 @@ class Grid extends Component {
         selectedRows: object,
         showTreeRootNode: bool,
         stateKey: string,
+        stateful: bool,
         store: object
     };
 
@@ -353,14 +354,23 @@ class Grid extends Component {
 
     setColumns() {
 
-        const { columns, stateKey, store } = this.props;
+        const { columns, stateKey, store, stateful } = this.props;
+        let savedColumns = columns;
+
+        if (stateful) {
+            savedColumns = localStorageManager.getStateItem(
+                { stateKey, value: columns, property: 'columns' }
+            );
+        }
 
         if (!columns) {
             throw new Error('A columns array is required');
         }
 
         else {
-            store.dispatch(setColumns({ columns, stateKey }));
+            store.dispatch(setColumns(
+                { columns: savedColumns, stateKey, stateful })
+            );
         }
     }
 }

--- a/src/components/core/ColumnManager.js
+++ b/src/components/core/ColumnManager.js
@@ -114,7 +114,8 @@ export default class ColumnManager {
         rowData,
         rowIndex,
         menuState,
-        stateKey
+        stateKey,
+        stateful
     }) {
 
         const { GRID_ACTIONS } = this.plugins;
@@ -123,13 +124,14 @@ export default class ColumnManager {
             actions: GRID_ACTIONS,
             store: this.store,
             type,
-            columns: this.columns,
+            columns: columns || this.columns,
             rowId: id,
             rowData,
             rowIndex,
             editor: this.editor,
             reducerKeys,
             selModel: this.selModel,
+            stateful,
             stateKey,
             menuState,
             gridState: columns,

--- a/src/components/core/LocalStorageManager.js
+++ b/src/components/core/LocalStorageManager.js
@@ -1,0 +1,46 @@
+import { debounce } from './../../util/throttle';
+
+export class LocalStorageManager {
+
+    setStateItem({ stateKey, property, value }) {
+
+        const json = JSON.stringify(value);
+
+        window.localStorage.setItem(
+            this.getKey({ stateKey, property }), json
+        );
+    }
+
+    debouncedSetStateItem() {
+        return debounce(this.setStateItem.bind(this), 500, false);
+    }
+
+    getStateItem({ stateKey, property, value, shouldSave = true }) {
+
+        const item = window.localStorage.getItem(
+            this.getKey({ stateKey, property })
+        );
+
+        if (item) {
+            return JSON.parse(item);
+        }
+
+        if (value && shouldSave) {
+            this.setStateItem({ stateKey, property, value });
+        }
+
+        return value;
+    }
+
+    getKey({ stateKey, property }) {
+
+        if (!stateKey || !property) {
+            throw new Error('stateKey and property are required params');
+        }
+
+        return `react-grid-${stateKey}-${property}`;
+    }
+
+}
+
+export default new LocalStorageManager();

--- a/src/components/layout/FixedHeader.jsx
+++ b/src/components/layout/FixedHeader.jsx
@@ -11,7 +11,7 @@ import { isPluginEnabled } from '../../util/isPluginEnabled';
 import { CLASS_NAMES } from '../../constants/GridConstants';
 import { resizeColumns } from '../../actions/GridActions';
 
-const { arrayOf, object, string } = PropTypes;
+const { arrayOf, bool, object, string } = PropTypes;
 
 const dragAndDropManager = new DragAndDropManager();
 
@@ -27,6 +27,7 @@ class FixedHeader extends Component {
             reducerKeys,
             selectionModel,
             stateKey,
+            stateful,
             store,
             pager,
             plugins,
@@ -56,6 +57,7 @@ class FixedHeader extends Component {
                 pager,
                 store,
                 stateKey,
+                stateful,
                 visibleColumns,
                 key: `fixed-header-${i}`
             };
@@ -131,6 +133,7 @@ class FixedHeader extends Component {
             id: 'header-row',
             reducerKeys,
             stateKey,
+            stateful,
             menuState
         });
 
@@ -220,6 +223,7 @@ class FixedHeader extends Component {
         reducerKeys: object,
         selectionModel: object,
         stateKey: string,
+        stateful: bool,
         store: object
     };
 
@@ -372,6 +376,7 @@ export const handleDrag = (
     store,
     nextColumnKey,
     stateKey,
+    stateful,
     reactEvent
 ) => {
 
@@ -417,7 +422,8 @@ export const handleDrag = (
             width: nextColWidth
         },
         columns,
-        stateKey
+        stateKey,
+        stateful
     }));
 
 };

--- a/src/components/layout/header/Column.jsx
+++ b/src/components/layout/header/Column.jsx
@@ -20,8 +20,17 @@ const isChrome = /Chrome/.test(navigator.userAgent)
     && /Google Inc/.test(navigator.vendor);
 
 export const Column = ({
-    scope, col, columns, columnManager, dataSource,
-    dragAndDropManager, pager, store, stateKey, index
+    scope,
+    col,
+    columns,
+    columnManager,
+    dataSource,
+    dragAndDropManager,
+    pager,
+    store,
+    stateKey,
+    index,
+    stateful
 }) => {
 
     if (col.hidden) {
@@ -54,7 +63,8 @@ export const Column = ({
         columnManager,
         store,
         nextColumnKey,
-        stateKey
+        stateKey,
+        stateful
     );
 
     const sortHandle = sortable
@@ -99,7 +109,9 @@ export const Column = ({
     const headerProps = {
         className: headerClass,
         onClick: handleColumnClick.bind(scope, clickArgs),
-        onDrop: handleDrop.bind(scope, index, columns, stateKey, store),
+        onDrop: handleDrop.bind(
+            scope, index, columns, stateful, stateKey, store
+        ),
         onDragOver: (reactEvent) => {
             reactEvent.preventDefault();
         },
@@ -119,19 +131,23 @@ export const Column = ({
         headerProps.onDragOver = (reactEvent) => {
             // due to a bug in firefox, we need to set a global to
             // preserve the x coords
-            // http://stackoverflow.com/questions/11656061/event-clientx-showing-as-0-in-firefox-for-dragend-event
+            // http://stackoverflow.com/questions/11656061/
+            // event-clientx-showing-as-0-in-firefox-for-dragend-event
             window.reactGridXcoord = reactEvent.clientX;
             reactEvent.preventDefault();
         };
     }
 
     const innerHTML = (
-        <Text { ...{ col,
-            index,
-            columnManager,
-            dragAndDropManager,
-            sortHandle } }
-        />
+        <Text {
+            ...{
+                col,
+                index,
+                columnManager,
+                dragAndDropManager,
+                sortHandle
+            }
+        } />
     );
 
     return (
@@ -152,11 +168,12 @@ Column.propTypes = {
     pager: PropTypes.object,
     scope: PropTypes.object,
     stateKey: PropTypes.string,
+    stateful: PropTypes.bool,
     store: PropTypes.object
 };
 
 export const handleDrop = (
-    droppedIndex, columns, stateKey, store, reactEvent
+    droppedIndex, columns, stateful, stateKey, store, reactEvent
 ) => {
 
     reactEvent.preventDefault();
@@ -172,7 +189,8 @@ export const handleDrop = (
                     draggedIndex: colData.index,
                     droppedIndex: droppedIndex,
                     columns,
-                    stateKey
+                    stateKey,
+                    stateful
                 })
             );
         }
@@ -180,7 +198,9 @@ export const handleDrop = (
     }
 
     catch (e) {
+        /* eslint-disable no-console */
         console.warn('Invalid drop');
+        /* eslint-enable no-console */
     }
 
 };

--- a/src/components/plugins/bulkactions/Toolbar.jsx
+++ b/src/components/plugins/bulkactions/Toolbar.jsx
@@ -111,16 +111,14 @@ export const getToolbar = (actions, bulkActionState, selectedRows) => {
 
     const spanProps = {
         className: prefix(CLASS_NAMES.BULK_ACTIONS.DESCRIPTION),
-        text: `${totalCount} Selected`
+        children: `${totalCount} Selected`
     };
 
     const buttons = actions.map(getAction);
 
     return (
         <div { ...containerProps } >
-            <span { ...spanProps } >
-                { spanProps.text }
-            </span>
+            <span { ...spanProps } />
             { buttons }
         </div>
     );
@@ -129,15 +127,13 @@ export const getToolbar = (actions, bulkActionState, selectedRows) => {
 export const getAction = (action) => {
 
     const buttonProps = {
-        text: action.text,
+        children: action.text,
         onClick: action.EVENT_HANDLER,
         key: keyFromObject(action)
     };
 
     return (
-        <button { ...buttonProps } >
-            { buttonProps.text }
-        </button>
+        <button { ...buttonProps } />
     );
 };
 

--- a/src/components/plugins/gridactions/ActionColumn.jsx
+++ b/src/components/plugins/gridactions/ActionColumn.jsx
@@ -20,6 +20,7 @@ export const ActionColumn = ({
     rowData,
     store,
     stateKey,
+    stateful,
     type,
     rowIndex,
     reducerKeys
@@ -50,35 +51,27 @@ export const ActionColumn = ({
         className
     };
 
+    const actionArgs = [
+        columns,
+        containerProps,
+        iconProps,
+        menuShown,
+        actions,
+        columns,
+        store,
+        editor,
+        reducerKeys,
+        rowId,
+        rowData,
+        rowIndex,
+        stateKey,
+        stateful,
+        headerActionItemBuilder
+    ];
+
     return type === 'header'
-        ? getHeader(
-            columns,
-            containerProps,
-            iconProps,
-            menuShown,
-            columns,
-            store,
-            editor,
-            reducerKeys,
-            rowId,
-            rowData,
-            rowIndex,
-            stateKey,
-            headerActionItemBuilder
-        ) : getColumn(
-            columns,
-            containerProps,
-            iconProps,
-            menuShown,
-            actions,
-            store,
-            editor,
-            reducerKeys,
-            rowId,
-            rowData,
-            rowIndex,
-            stateKey
-        );
+        ? getHeader(...actionArgs)
+        : getColumn(...actionArgs);
 };
 
 ActionColumn.propTypes = {
@@ -88,6 +81,7 @@ ActionColumn.propTypes = {
     iconCls: PropTypes.string,
     menuState: PropTypes.object,
     rowId: PropTypes.string,
+    stateful: PropTypes.bool,
     store: PropTypes.object,
     type: PropTypes.string
 };
@@ -139,6 +133,7 @@ export const getHeader = (
     containerProps,
     iconProps,
     menuShown,
+    actions,
     columns,
     store,
     editor,
@@ -147,14 +142,15 @@ export const getHeader = (
     rowData,
     rowIndex,
     stateKey,
+    stateful,
     headerActionItemBuilder
 ) => {
 
-    let actions;
+    let colActions;
 
     if (!headerActionItemBuilder) {
 
-        actions = columns.map((col) => {
+        colActions = columns.map((col) => {
 
             const isChecked = col.hidden !== undefined
                 ? !col.hidden : true;
@@ -174,7 +170,8 @@ export const getHeader = (
                                 columns,
                                 column: col,
                                 isHidden: col.hidden,
-                                stateKey
+                                stateKey,
+                                stateful
                             })
                         );
                     }
@@ -185,25 +182,28 @@ export const getHeader = (
     }
 
     else {
-        actions = columns.map(headerActionItemBuilder.bind(null, {
+        colActions = columns.map(headerActionItemBuilder.bind(null, {
             store
         }));
     }
 
     const menuItems = {
-        menu: actions
+        menu: colActions
     };
 
     const menu = menuShown ?
-        <Menu { ...{ columns: cols,
-            actions: menuItems,
-            type: 'header',
-            store,
-            editor,
-            reducerKeys,
-            rowId,
-            stateKey } }
-        />
+        <Menu {
+            ...{
+                columns: cols,
+                actions: menuItems,
+                type: 'header',
+                store,
+                editor,
+                reducerKeys,
+                rowId,
+                stateKey
+            }
+        } />
         : null;
 
     return (
@@ -221,10 +221,8 @@ export const addKeysToActions = (action) => {
         return action;
     }
 
-    else {
-        action.key = keyFromObject(action);
-        return action;
-    }
+    action.key = keyFromObject(action);
+    return action;
 };
 
 export const getColumn = (
@@ -233,6 +231,7 @@ export const getColumn = (
     iconProps,
     menuShown,
     actions,
+    columns,
     store,
     editor,
     reducerKeys,
@@ -244,18 +243,20 @@ export const getColumn = (
 
     const menu = menuShown
         ?
-        <Menu { ...{
-            actions: addKeysToActions(actions),
-            type: null,
-            rowData,
-            store,
-            editor,
-            reducerKeys,
-            rowId,
-            columns: cols,
-            stateKey,
-            rowIndex } }
-        />
+        <Menu {
+            ...{
+                actions: addKeysToActions(actions),
+                type: null,
+                rowData,
+                store,
+                editor,
+                reducerKeys,
+                rowId,
+                columns: cols,
+                stateKey,
+                rowIndex
+            }
+        } />
         : null;
 
     if (actions && actions.menu && actions.menu.length === 0) {

--- a/src/reducers/components/grid.js
+++ b/src/reducers/components/grid.js
@@ -7,9 +7,15 @@ import {
     HIDE_HEADER
 } from './../../constants/ActionTypes';
 
+import
+    localStorageManager
+from './../../components/core/LocalStorageManager';
+
 import { generateLastUpdate } from './../../util/lastUpdate';
 
 const initialState = fromJS({ lastUpdate: generateLastUpdate() });
+
+const debouncedColumnSetter = localStorageManager.debouncedSetStateItem();
 
 export default function gridState(state = initialState, action) {
 
@@ -22,6 +28,14 @@ export default function gridState(state = initialState, action) {
         }));
 
     case SET_COLUMNS:
+
+        if (action.stateful) {
+            setColumnsInStorage({
+                stateKey: action.stateKey,
+                columns: action.columns
+            });
+        }
+
         return state.mergeIn([action.stateKey], fromJS({
             columns: action.columns,
             lastUpdate: generateLastUpdate()
@@ -34,6 +48,14 @@ export default function gridState(state = initialState, action) {
         }));
 
     case RESIZE_COLUMNS:
+
+        if (action.stateful) {
+            setColumnsInStorage({
+                stateKey: action.stateKey,
+                columns: action.columns
+            });
+        }
+
         return state.mergeIn([action.stateKey], fromJS({
             columns: action.columns,
             lastUpdate: generateLastUpdate()
@@ -44,3 +66,11 @@ export default function gridState(state = initialState, action) {
         return state;
     }
 }
+
+export const setColumnsInStorage = ({ columns, stateKey }) => {
+    debouncedColumnSetter({
+        stateKey: stateKey,
+        property: 'columns',
+        value: columns
+    });
+};

--- a/test/actions/GridActions.test.js
+++ b/test/actions/GridActions.test.js
@@ -193,7 +193,8 @@ describe('The setColumns actions', () => {
                     name: 'col2'
                 }
             ],
-            stateKey
+            stateKey,
+            stateful: undefined
         });
     });
 
@@ -214,11 +215,13 @@ describe('The setColumns actions', () => {
 
         expect(setColumns({
             columns: colsWithIds,
-            stateKey
+            stateKey,
+            stateful: true
         })).toEqual({
             type: 'SET_COLUMNS',
             columns: colsWithIds,
-            stateKey
+            stateKey,
+            stateful: true
         });
 
     });
@@ -352,6 +355,7 @@ describe('The setColumnVisibility actions', () => {
             })
         ).toEqual({
             stateKey: 'test-grid',
+            stateful: undefined,
             columns: [
                 {
                     name: 'col1',
@@ -395,6 +399,7 @@ describe('The setColumnVisibility actions', () => {
             })
         ).toEqual({
             stateKey: 'test-grid',
+            stateful: undefined,
             columns: [
                 {
                     name: 'col1',
@@ -457,6 +462,7 @@ describe('The resizeColumns action', () => {
             })
         ).toEqual({
             stateKey: 'test-grid',
+            stateful: undefined,
             columns: [
                 {
                     name: 'col1',
@@ -493,10 +499,12 @@ describe('The resizeColumns action', () => {
                 width: '20',
                 id: '1',
                 nextColumn: {},
-                stateKey: 'test-grid'
+                stateKey: 'test-grid',
+                stateful: true
             })
         ).toEqual({
             stateKey: 'test-grid',
+            stateful: true,
             columns: [
                 {
                     name: 'col1',

--- a/test/actions/core/ColumnManager.test.js
+++ b/test/actions/core/ColumnManager.test.js
@@ -48,6 +48,7 @@ describe('The reorderColumn gridAction', () => {
                     }
                 ],
                 stateKey: 'test-grid',
+                stateful: undefined,
                 type: SET_COLUMNS
             });
     });
@@ -90,6 +91,7 @@ describe('The reorderColumn gridAction', () => {
                     }
                 ],
                 stateKey: 'test-grid',
+                stateful: undefined,
                 type: SET_COLUMNS
             });
     });

--- a/test/components/core/LocalStorageManager.test.js
+++ b/test/components/core/LocalStorageManager.test.js
@@ -1,0 +1,172 @@
+import expect from 'expect';
+
+import
+    localStorageManager
+from './../../../src/components/core/LocalStorageManager';
+
+// set spy for browswer local storage
+if (!window.localStorage) {
+    window.localStorage = {};
+    window.localStorage.setItem = sinon.spy();
+
+    describe('The gtid local storage manager', () => {
+
+        it('Should return the appropriate storage key', () => {
+
+            expect(
+                localStorageManager.getKey({
+                    stateKey: 'some-grid',
+                    property: 'columns'
+                })
+            ).toEqual('react-grid-some-grid-columns');
+
+        });
+
+        it('Should throw an error if stateKey is not passed', () => {
+            expect(() => {
+                localStorageManager.getKey({
+                    stateKey: '',
+                    property: 'columns'
+                });
+            }).toThrow('stateKey and property are required params');
+        });
+
+        it('Should throw an error if property is not passed', () => {
+            expect(() => {
+                localStorageManager.getKey({
+                    stateKey: 'some-grid',
+                    property: null
+                });
+            }).toThrow('stateKey and property are required params');
+        });
+
+        it('Should set an item in local storage', () => {
+
+            localStorageManager.setStateItem({
+                stateKey: 'some-grid',
+                property: 'columns',
+                value: [
+                    {
+                        dataIndex: 1
+                    },
+                    {
+                        dataIndex: 2
+                    }
+                ]
+            });
+
+            expect(
+                window.localStorage.setItem.called
+            ).toEqual(true);
+
+        });
+
+        it('Should return an item from local storage', () => {
+
+            window.localStorage.getItem = (key) => {
+                const storage = {
+                    'react-grid-some-grid-height': '40'
+                };
+
+                return storage[key];
+            };
+
+            expect(
+                localStorageManager.getStateItem({
+                    stateKey: 'some-grid',
+                    property: 'height'
+                })
+            ).toEqual('40');
+
+        });
+
+        it('Should should debounce the setItem func', (done) => {
+
+            window.localStorage.setItem = sinon.spy();
+
+            const debounced = localStorageManager.debouncedSetStateItem();
+
+            const func = () => {
+                debounced({
+                    stateKey: 'debounced-grid',
+                    property: 'columns',
+                    value: []
+                });
+            };
+
+            for (let i = 0; i < 10; i++) {
+                func();
+            }
+
+            setTimeout(() => {
+                expect(
+                    window.localStorage.setItem.callCount
+                ).toEqual(1);
+                done();
+            }, 600);
+
+        });
+
+        it('Should save an item if it doesnt exist in storage', () => {
+
+            let storage;
+
+            window.localStorage.getItem = (key) => {
+                storage = {
+                    'react-grid-some-grid-height': '40'
+                };
+
+                return storage[key];
+            };
+
+            window.localStorage.setItem = (key, value) => {
+                storage[key] = value;
+            };
+
+            expect(
+                localStorageManager.getStateItem({
+                    stateKey: 'some-grid',
+                    property: 'somenumber',
+                    value: 1
+                })
+            ).toEqual(1);
+
+            expect(storage['react-grid-some-grid-somenumber']).toEqual('1');
+
+        });
+
+        it(['Shouldnt save an item if it doesnt exist in storage',
+            'and flag is passed'].join(' '), () => {
+
+            let storage;
+
+            window.localStorage.getItem = (key) => {
+                storage = {
+                    'react-grid-some-grid-height': '40'
+                };
+
+                return storage[key];
+            };
+
+            window.localStorage.setItem = (key, value) => {
+                storage[key] = value;
+            };
+
+            expect(
+                localStorageManager.getStateItem({
+                    stateKey: 'some-grid',
+                    property: 'somenumber',
+                    value: 1,
+                    shouldSave: false
+                })
+            ).toEqual(1);
+
+            expect(
+                storage['react-grid-some-grid-somenumber']
+            ).toEqual(undefined);
+
+        });
+
+    });
+
+}


### PR DESCRIPTION
Adding `stateful` as grid level paramater so column configuration will be stored as object in the browser local storage.

**Important Note:** data is saved using `stateKey`, so this key must be unique across all grids in a single application, otherwise there could be a collision of column-state.