### PR TITLE
pager action checks if data source is a function

### DIFF
--- a/src/actions/plugins/pager/PagerActions.js
+++ b/src/actions/plugins/pager/PagerActions.js
@@ -94,6 +94,7 @@ export function setPageAsync({
 }) {
 
     const pageIndex = type === BUTTON_TYPES.NEXT ? index + 1 : index - 1;
+    let apiPromise
 
     return (dispatch) => {
 
@@ -101,14 +102,21 @@ export function setPageAsync({
             setLoaderState({ state: true, stateKey })
         );
 
-        return Request.api({
-            route: dataSource,
-            method: 'POST',
-            data: {
-                pageIndex: pageIndex,
-                pageSize: pageSize
-            }
-        }).then((response) => {
+        if ( typeof dataSource == 'function' ) {
+            apiPromise = dataSource( { pageIndex: pageIndex, pageSize: pageSize }, {}, null );
+        }
+        else {
+            apiPromise = Request.api({
+                route: dataSource,
+                method: 'POST',
+                data: {
+                    pageIndex: pageIndex,
+                    pageSize: pageSize
+                }
+            })
+        }
+
+        return apiPromise.then((response) => {
 
             if (response && response.data) {
 


### PR DESCRIPTION
Howdy!

There's a bug report in this pull request, and a bit of a story, so grab a chair...

Background: I'm using react-redux-grid with a `dataSource` which is a custom function that returns a promise. (This lets me add authorization and header details I need for the remote API).

I also want my paging type to be `'remote'` also.

I believe(d) that this page configuration would work:
```
			PAGER: {
				enabled: true,
				pagingType: 'remote'
                        }
```

and that react-redux-grid would use the `dataSource` I had set up.

In fact, what happens is PagerActions `setPageAsync` function's `dataSource` parameter set to `{ currentRecords: ..., data: ..., gridType: ...., lastUpdate: ...., proxy: ...., total: ...., treeData: ...}`. What parent components call `gridData`. 

Regardless *why* this gets passed an object, when it does pass an object, it tries to make an AJAX request to `http://[Object]`. (See https://github.com/bencripps/react-redux-grid/blob/master/src/actions/plugins/pager/PagerActions.js#L105 ). It's trying to serialize the `gridData` structure as a string then call that host.

But even in this object there's no reference back to my promise (that I could see).

Sooooo I set `PAGER.pagingSource` explicitly to the same function as I use for `dataSource`.

Which meant that `setPageAsync`'s `dataSource` **was** what I wanted - a function! Except I immediately ran into the same bug as above: trying to send an AJAX request to `http://[Function]`.

SOOOOOOO this patch: check to see if `dataSource` is a function. If it is, use that to get a promise. Else, call `Request.api` as before.

There is still a bug here: if you set pagingType to remote, but don't provide a `pagingSource`, why is the data source a record? Don't know - in my use case I'm fine with having `pagingSource` need to be provided / a function (in fact, my code will have to be structured that way for other reasons... like `setPageAsync` not knowing the current sorting of the grid from down in the PagerActions Plain Old Javascript Class. (If there's a way let me know ;) )

Let me know if there's anything I can do to get this accepted. Thanks!
