### PR TITLE
style callback for rows

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -512,6 +512,19 @@ Bulk Action Defaults
 1. `enabled`: `string`, whether the bulk action toolbar should be used
 2. `actions`: `array of objects`, the actions (including button text, and event handler) that will be displayed in the bar
 
+
+## Row Manager
+
+```javascript
+export const plugins = {
+    ROW_MANAGER: {
+        styleRenderer: ( ( row ) => {
+            return { backgroundColor: 'red' }
+        } )
+    }
+}
+```
+
 ## Events
 
 All grid events are passed in as a single object.

--- a/src/components/layout/table-row/Row.jsx
+++ b/src/components/layout/table-row/Row.jsx
@@ -105,6 +105,12 @@ export class Row extends Component {
             ? CLASS_NAMES.ROW_IS_DRAGGING
             : '';
 
+        let extraStyles = {}
+
+        if ( plugins.ROW_MANAGER && plugins.ROW_MANAGER.styleRenderer ) {
+            extraStyles = plugins.ROW_MANAGER.styleRenderer( row )
+        }
+
         const rowProps = {
             className: prefix(
                 CLASS_NAMES.ROW,
@@ -121,7 +127,8 @@ export class Row extends Component {
                 handleRowDoubleClickEvent(
                     events, row, id, selectionModel, index, e
                 );
-            }
+            },
+            style: extraStyles
         };
 
         columnManager.addActionColumn({


### PR DESCRIPTION
Try this on for style:

I needed to be able to style _rows_, and to style a row based on the kind of data inside the row (and by that I mean, can be different from row to row). 

So I created a plugin configuration that let me specify a style function.

Maybe it's useful, maybe there's a better way to do it, but it solved a need I have.

Let me know if there's anything I should do in order to get this merged
