### PR TITLE
Tree DnD fixes with drop and cancel drop

### DIFF
--- a/src/constants/GridConstants.js
+++ b/src/constants/GridConstants.js
@@ -6,6 +6,9 @@ export const DEFAULT_PAGE_SIZE = 20;
 
 export const DEFAULT_RENDERED_RECORDS_VISIBLE = 200;
 
+export const BUFFER_MULTIPLIER = 1.5;
+export const DEFAULT_VIEWABLE_RECORDS = 25;
+
 export const SELECTION_MODES = {
     single: 'single',
     multi: 'multi',

--- a/test/integration/empty-data.test.js
+++ b/test/integration/empty-data.test.js
@@ -24,16 +24,15 @@ const props = {
     store: GridStore
 };
 
-describe('Integration Test for Column custom sort fn', () => {
+describe('Empty data row', () => {
 
-    const component = mount(<ConnectedGrid { ...props } />);
+    const wrapper = mount(<ConnectedGrid { ...props } />);
 
     it('Should render a message based on props', (done) => {
 
         setTimeout(() => {
 
-            const emptyRow = component
-                .find('.react-grid-empty-row');
+            const emptyRow = wrapper.find('.react-grid-empty-row');
 
             expect(
                 emptyRow.html()


### PR DESCRIPTION
Refactored `TableRow.jsx` to be a little bit more manageable.

#### Tree Drag and Drop changes:
- Drop event now fires for row that was moved vs the row that was dropped
- You can undo a drop move by dragging row outside of grid