### PR TITLE
fix utf8 in column names

### DIFF
--- a/src/util/keyGenerator.js
+++ b/src/util/keyGenerator.js
@@ -1,5 +1,5 @@
 export function keyGenerator(...keywords) {
-    return btoa(Array.from(keywords).join(''));
+    return btoa(unescape(encodeURIComponent(Array.from(keywords).join(''))));
 }
 
 export function keyFromObject(obj, additionalStrings) {


### PR DESCRIPTION
I'm not sure about keyFromObject function, think that it is not necessary to do the same in it, because it call  btoa on object keys and error may occur only if we pass utf8 symbols in additionalStrings parameter. I will add the same fix here if you ask.