### PR TITLE
Added PropType validation of 'any' for emptyDataMessage

### DIFF
--- a/src/components/layout/TableRow.jsx
+++ b/src/components/layout/TableRow.jsx
@@ -23,7 +23,7 @@ import {
 import Row from './table-row/Row';
 import { PlaceHolder } from './row/PlaceHolder';
 
-const { arrayOf, bool, func, number, object, string } = PropTypes;
+const { any, arrayOf, bool, func, number, object, string } = PropTypes;
 
 export class TableRow extends Component {
 
@@ -88,7 +88,7 @@ export class TableRow extends Component {
         dragAndDrop: bool,
         editor: object,
         editorState: object,
-        emptyDataMessage: string,
+        emptyDataMessage: any,
         events: object,
         gridType: GRID_TYPES,
         infinite: bool,

--- a/src/components/layout/table-row/Row.jsx
+++ b/src/components/layout/table-row/Row.jsx
@@ -11,7 +11,7 @@ import { fire } from '../../../util/fire';
 import { getData, getRowKey } from '../../../util/getData';
 import { gridConfig } from '../../../constants/GridConstants';
 
-const { arrayOf, bool, func, object, string, oneOf, number } = PropTypes;
+const { any, arrayOf, bool, func, object, string, oneOf, number } = PropTypes;
 
 const DRAG_INCREMENT = 15;
 
@@ -183,7 +183,7 @@ export class Row extends Component {
         dragAndDrop: bool,
         editor: object,
         editorState: object,
-        emptyDataMessage: string,
+        emptyDataMessage: any,
         events: object,
         findRow: func.isRequired,
         gridType: oneOf([


### PR DESCRIPTION
`emptyDataMessage` was originally added with PropType.any in [Grid.jsx:200](https://github.com/bencripps/react-redux-grid/blob/master/src/components/Grid.jsx#L200), but was set to `string` further down the component chain.