### PR TITLE
Move Api from plugins to Util, add testing for AJAX actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "stylus-loader": "^2.3.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
-    "webpack-dev-server": "^1.16.1"
+    "webpack-dev-server": "^1.16.1",
+    "xmlhttprequest": "^1.8.0"
   }
 }

--- a/src/actions/GridActions.js
+++ b/src/actions/GridActions.js
@@ -19,7 +19,7 @@ import { keyGenerator } from '../util/keyGenerator';
 
 import { treeToFlatList } from '../util/treeToFlatList';
 
-import Request from '../components/plugins/ajax/Request';
+import Api from '../util/api';
 
 export const getAsyncData = ({
     stateKey, dataSource, type, showTreeRootNode, extraParams = {}
@@ -108,7 +108,7 @@ export const getAsyncData = ({
 
             if (type !== 'tree') {
 
-                return Request.api({
+                return Api({
                     route: dataSource,
                     method: 'GET'
                 }).then((response) => {
@@ -143,7 +143,7 @@ export const getAsyncData = ({
 
             }
 
-            return Request.api({
+            return Api({
                 route: dataSource,
                 method: 'GET',
                 queryStringParams: {
@@ -283,7 +283,7 @@ export const doRemoteSort = ({
 
         }
 
-        return Request.api({
+        return Api({
             route: dataSource,
             method: 'POST',
             data: {

--- a/src/actions/plugins/pager/PagerActions.js
+++ b/src/actions/plugins/pager/PagerActions.js
@@ -9,7 +9,7 @@ import { setLoaderState } from '../../../actions/plugins/loader/LoaderActions';
 
 import { dismissEditor } from '../../../actions/plugins/editor/EditorActions';
 
-import Request from '../../../components/plugins/ajax/Request';
+import Api from '../../../util/api';
 
 export const setPage = ({ index, type, BUTTON_TYPES }) => {
     const pageIndex = type === BUTTON_TYPES.NEXT ? index + 1 : index - 1;
@@ -108,7 +108,7 @@ export const setPageAsync = ({
             setLoaderState({ state: true, stateKey })
         );
 
-        return Request.api({
+        return Api({
             route: dataSource,
             method: 'GET',
             queryStringParams: {

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -1,4 +1,4 @@
-function api(config) {
+export const Api = (config) => {
     const promise = new Promise((resolve) => {
 
         if (!config.method) {
@@ -24,9 +24,9 @@ function api(config) {
     });
 
     return promise;
-}
+};
 
-function setRequestHeaders(request, config) {
+export const setRequestHeaders = (request = {}, config = {}) => {
 
     if (!config.headers || !config.headers.contentType) {
         request.setRequestHeader(
@@ -39,11 +39,11 @@ function setRequestHeaders(request, config) {
     }
 
     for (const key of Object.keys(config.headers)) {
-        request.setRequestHeader(key, config.additionalHeaders[key]);
+        request.setRequestHeader(key, config.headers[key]);
     }
-}
+};
 
-function addAjaxEvents(request, config, resolver) {
+export const addAjaxEvents = (request, config, resolver) => {
 
     const getResponse = () => {
         try {
@@ -60,27 +60,25 @@ function addAjaxEvents(request, config, resolver) {
     request.addEventListener(
         'load', getResponse.bind(config.onSuccess, config.onSuccess)
     );
-}
+};
 
-function buildQueryString(config) {
+export const buildQueryString = (config = {}) => {
 
-    let builtUrl = config.route + '?' + '_dc=' + Date.now() + '&';
+    const ret = {
+        route: config.route + '?' + '_dc=' + Date.now() + '&'
+    };
 
     if (!config.queryStringParams) {
-        return config;
+        return ret;
     }
 
     for (const key of Object.keys(config.queryStringParams)) {
         if (config.queryStringParams[key]) {
-            builtUrl += key + '=' + config.queryStringParams[key] + '&';
+            ret.route += key + '=' + config.queryStringParams[key] + '&';
         }
     }
 
-    config.route = builtUrl;
-}
-
-const Request = {
-    api: api
+    return ret;
 };
 
-export default Request;
+export default Api;

--- a/test/actions/GridActions.test.js
+++ b/test/actions/GridActions.test.js
@@ -16,6 +16,63 @@ import {
 
 describe('The getAsyncData actions', () => {
 
+    it('Should return a successful res with a string', (done) => {
+
+        const res = [];
+
+        getAsyncData({
+            dataSource: 'some/url',
+            stateKey: 'test-grid'
+        })((resp) => {
+            res.push(resp);
+        });
+
+        setTimeout(() => {
+            expect(res).toEqual([
+                {
+                    stateKey: 'test-grid',
+                    type: '@@react-redux-grid/DISMISS_EDITOR'
+                },
+                {
+                    state: true,
+                    stateKey: 'test-grid',
+                    type: '@@react-redux-grid/SET_LOADING_STATE'
+                }
+            ]);
+            done();
+        }, 10);
+
+    });
+
+    it('Should return a successful res with a string as tree', (done) => {
+
+        const res = [];
+
+        getAsyncData({
+            dataSource: 'some/url',
+            stateKey: 'test-grid',
+            type: 'tree'
+        })((resp) => {
+            res.push(resp);
+        });
+
+        setTimeout(() => {
+            expect(res).toEqual([
+                {
+                    stateKey: 'test-grid',
+                    type: '@@react-redux-grid/DISMISS_EDITOR'
+                },
+                {
+                    state: true,
+                    stateKey: 'test-grid',
+                    type: '@@react-redux-grid/SET_LOADING_STATE'
+                }
+            ]);
+            done();
+        }, 10);
+
+    });
+
     it('Should return a successful res with a function', (done) => {
 
         const read = () => {
@@ -166,6 +223,35 @@ describe('The getAsyncData actions', () => {
 
     });
 
+    it([
+        'Should return the correct remote sort ',
+        'response when datasource is a string'].join(''), (done) => {
+        const res = [];
+
+        const dispatch = val => (res.push(val));
+
+        doRemoteSort({
+            dataSource: 'some/url',
+            pageIndex: 1,
+            pageSize: 30,
+            sortParams: {
+                name: 'ASC'
+            },
+            stateKey: 'test-grid'
+        })(dispatch);
+
+        setTimeout(() => {
+            expect(res).toEqual([
+                {
+                    state: true,
+                    stateKey: 'test-grid',
+                    type: '@@react-redux-grid/SET_LOADING_STATE'
+                }
+            ]);
+            done();
+        }, 10);
+
+    });
 });
 
 describe('The setColumns actions', () => {

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -76,6 +76,7 @@ module.exports = function exports(config) {
             },
             externals: {
                 cheerio: 'window',
+                window: 'window',
                 'react/lib/ExecutionEnvironment': true,
                 'react/lib/ReactContext': true
             },

--- a/test/util/api.test.js
+++ b/test/util/api.test.js
@@ -1,0 +1,113 @@
+import expect from 'expect';
+
+import {
+    setRequestHeaders,
+    buildQueryString,
+    Api
+} from './../../src/util/api';
+
+describe('The Api Utility', () => {
+
+    it('Should return a promise', () => {
+        const promise = Api({
+            route: 'some/url',
+            method: 'POST',
+            data: {
+                someData: 'hello'
+            }
+        });
+
+        expect(promise.then).toBeTruthy();
+    });
+
+    it('Should return a promise with a GET', () => {
+        const promise = Api({
+            route: 'some/url',
+            data: {
+                someData: 'hello'
+            }
+        });
+
+        expect(promise.then).toBeTruthy();
+    });
+
+});
+
+describe('The Api setRequestHeaders function', () => {
+
+    it('Should set request headers on a request object', () => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', 'some/route', true);
+
+        const config = {
+            headers: {
+                someProp: true
+            }
+        };
+
+        expect(
+            () => setRequestHeaders(xhr, config)
+        ).toNotThrow();
+
+    });
+
+    it('Should set content type', () => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', 'some/route', true);
+
+        const config = {
+            headers: {
+                contentType: 'applicaton/json'
+            }
+        };
+
+        expect(
+            () => setRequestHeaders(xhr, config)
+        ).toNotThrow();
+
+    });
+
+    it('Should set only content type', () => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', 'some/route', true);
+
+        const config = {};
+
+        expect(
+            () => setRequestHeaders(xhr, config)
+        ).toNotThrow();
+
+    });
+
+});
+
+describe('The Api buildQueryString func', () => {
+
+    it('Should build a URL with no query string', () => {
+        const config = {
+            route: 'some/url'
+        };
+
+        expect(
+            buildQueryString(config).route
+        ).toContain('some/url?_dc=');
+
+    });
+
+    it('Should build a URL with a query string', () => {
+        const config = {
+            route: 'some/url',
+            queryStringParams: {
+                newThing: true,
+                item: 'hello'
+            }
+        };
+
+        expect(
+            buildQueryString(config).route
+        ).toContain('&newThing=true&item=hello&');
+
+    });
+
+});
+


### PR DESCRIPTION
* Remove Request.js from plugins/ajax
* Add api as a utility
* Add testing for api util
* Add test coverage for grid actions, where `dataSource` is a `string`.