### PR TITLE
Feature/css optional

### DIFF
--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -30,6 +30,8 @@ import { isPluginEnabled } from '../util/isPluginEnabled';
 import { getColumnsFromStorage } from '../util/getColumnsFromStorage';
 import localStorageManager from './core/LocalStorageManager';
 
+import styles from './../style/main.styl';
+
 const {
     any,
     array,
@@ -41,8 +43,6 @@ const {
     string
 } = PropTypes;
 
-let _CSS_LOADED = false;
-
 export class Grid extends Component {
 
     render() {
@@ -51,9 +51,10 @@ export class Grid extends Component {
         const editorComponent = this.getEditor();
         const isLoading = this.isLoading();
 
-        if (!_CSS_LOADED && USE_GRID_STYLES) {
-            _CSS_LOADED = true;
-            require('./../style/main.styl');
+        if (!this.CSS_LOADED && USE_GRID_STYLES) {
+            this.CSS_LOADED = true;
+            console.log('loading styles');
+            this.addStyles();
         }
 
         const {
@@ -240,6 +241,8 @@ export class Grid extends Component {
         showTreeRootNode: false
     };
 
+    static CSS_LOADED = false;
+
     setGridDataType = asArray => {
         this._USING_DATA_ARRAY = asArray;
     };
@@ -406,6 +409,23 @@ export class Grid extends Component {
         && this.props.loadingState.isLoading
             ? this.props.loadingState.isLoading
             : false
+
+    addStyles = () => {
+        const styleEl = document.createElement('style');
+        const head = document.head
+            || document.getElementsByTagName('head')[0];
+
+        styleEl.type = 'text/css';
+
+        if (styleEl.styleSheet) {
+            styleEl.styleSheet.cssText = styles;
+        }
+        else {
+            styleEl.appendChild(document.createTextNode(styles));
+        }
+
+        head.appendChild(styleEl);
+    }
 }
 
 export default connect(mapStateToProps)(Grid);

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -12,7 +12,12 @@ import ColumnManager from './core/ColumnManager';
 import Model from './plugins/selection/Model';
 import Manager from './plugins/editor/Manager';
 import { prefix } from '../util/prefix';
-import { gridConfig, GRID_TYPES } from '../constants/GridConstants';
+
+import {
+    gridConfig,
+    GRID_TYPES
+} from '../constants/GridConstants';
+
 import {
     getAsyncData,
     setColumns,
@@ -25,8 +30,6 @@ import { isPluginEnabled } from '../util/isPluginEnabled';
 import { getColumnsFromStorage } from '../util/getColumnsFromStorage';
 import localStorageManager from './core/LocalStorageManager';
 
-import './../style/main.styl';
-
 const {
     any,
     array,
@@ -38,13 +41,20 @@ const {
     string
 } = PropTypes;
 
+let _CSS_LOADED = false;
+
 export class Grid extends Component {
 
     render() {
 
-        const { CLASS_NAMES } = gridConfig();
+        const { CLASS_NAMES, USE_GRID_STYLES } = gridConfig();
         const editorComponent = this.getEditor();
         const isLoading = this.isLoading();
+
+        if (!_CSS_LOADED && USE_GRID_STYLES) {
+            _CSS_LOADED = true;
+            require('./../style/main.styl');
+        }
 
         const {
             classNames,

--- a/src/constants/GridConstants.js
+++ b/src/constants/GridConstants.js
@@ -41,6 +41,8 @@ export const GRID_TYPES = PropTypes.oneOf(['grid', 'tree']);
 * these constants can be overridden by applyGridConfig
 */
 
+export let USE_GRID_STYLES = true;
+
 export let CSS_PREFIX = 'react-grid';
 
 export let CLASS_NAMES = {
@@ -145,10 +147,14 @@ export const applyGridConfig = (config = {})=> {
         else if (k === 'CSS_PREFIX') {
             CSS_PREFIX = config[k];
         }
+        else if (k === 'USE_GRID_STYLES') {
+            USE_GRID_STYLES = config[k];
+        }
     });
 };
 
 export const gridConfig = () => ({
     CLASS_NAMES,
-    CSS_PREFIX
+    CSS_PREFIX,
+    USE_GRID_STYLES
 });

--- a/src/style/components/header.styl
+++ b/src/style/components/header.styl
@@ -1,94 +1,94 @@
 +prefix-classes($prefix)
 
 
-    .header-fixed-container.hidden
-      opacity 0
+  .header-fixed-container.hidden
+    opacity 0
 
-    .header
-      background-color $lightcolor
-      border-bottom: 1px solid $strongcolor
-      color $fontcolor
-      font-family $fontfamily
-      height $headerheight
+  .header
+    background-color $lightcolor
+    border-bottom: 1px solid $strongcolor
+    color $fontcolor
+    font-family $fontfamily
+    height $headerheight
 
-      &.{$headerhidden}
-        visibility hidden
-
-        th
-          border none
-          height 0
-          padding-bottom 0
-          padding-top 0
-
-          &.checkbox-container
-            border none
-            height 0
-            margin 0
+    &.{$headerhidden}
+      visibility hidden
 
       th
-        position relative
-        text-overflow ellipsis
+        border none
+        height 0
+        padding-bottom 0
+        padding-top 0
 
         &.checkbox-container
-          border-bottom 1px solid $strongcolor
+          border none
+          height 0
+          margin 0
 
-          &.hidden
-            .checkbox
-              visibility hidden
+    th
+      position relative
+      text-overflow ellipsis
 
-        .column
-          display inline-block
-          height $headerheight
-          overflow hidden
-          position relative
-          text-overflow ellipsis
-          top 6px
-          width 80%
+      &.checkbox-container
+        border-bottom 1px solid $strongcolor
 
-        &.sort-handle-visible
-          .{$sorthandleclass}
-              visibility visible
+        &.hidden
+          .checkbox
+            visibility hidden
 
+      .column
+        display inline-block
+        height $headerheight
+        overflow hidden
+        position relative
+        text-overflow ellipsis
+        top 6px
+        width 80%
+
+      &.sort-handle-visible
         .{$sorthandleclass}
-          float left
-          transition(opacity)
-          visibility hidden
+          visibility visible
 
-          &.desc
-            icon('sort-up')
-            &::before
-              top -1px
+      .{$sorthandleclass}
+        float left
+        transition(opacity)
+        visibility hidden
 
-            &.asc
-              icon('sort-down')
+        &.desc
+          icon('sort-up')
+          &::before
+            top -1px
 
-            &::before
-              cursor pointer
-              position relative
-              right 1px
+          &.asc
+            icon('sort-down')
 
-        .{$draghandleclass}
+          &::before
+            cursor pointer
+            position relative
+            right 1px
 
-          &::after
-            border-right 1px solid $lightcolor
-            content ' '
-            cursor ew-resize
-            height 100%
-            position absolute
-            right 0
-            top 0
-            transition(border)
-            width: 10px
+      .{$draghandleclass}
 
-          &:hover
-            .{$draghandleclass}
-              &::after
-                border-color $strongcolor
+        &::after
+          border-right 1px solid $lightcolor
+          content ' '
+          cursor ew-resize
+          height 100%
+          position absolute
+          right 0
+          top 0
+          transition(border)
+          width: 10px
 
-      th:nth-last-child(1), th:nth-last-child(2)
-        overflow initial
+        &:hover
+          .{$draghandleclass}
+            &::after
+              border-color $strongcolor
 
-        .{$draghandleclass}
-          &::after
-            border none
-            cursor auto
+    th:nth-last-child(1), th:nth-last-child(2)
+      overflow initial
+
+      .{$draghandleclass}
+        &::after
+          border none
+          cursor auto

--- a/test/constants/GridConstants.test.js
+++ b/test/constants/GridConstants.test.js
@@ -2,7 +2,8 @@ import expect from 'expect';
 import {
     applyGridConfig,
     CLASS_NAMES,
-    CSS_PREFIX
+    CSS_PREFIX,
+    USE_GRID_STYLES
 } from './../../src/constants/GridConstants';
 
 describe('The applyGridConfig export', () => {
@@ -24,6 +25,7 @@ describe('The applyGridConfig export', () => {
         afterEach(() => {
             applyGridConfig({
                 CSS_PREFIX: 'react-grid',
+                USE_GRID_STYLES: true,
                 CLASS_NAMES: {
                     TABLE: 'table'
                 }
@@ -32,6 +34,7 @@ describe('The applyGridConfig export', () => {
 
         applyGridConfig({
             CSS_PREFIX: 'some new prefix',
+            USE_GRID_STYLES: false,
             CLASS_NAMES: {
                 TABLE: 'banana-table'
             }
@@ -46,6 +49,10 @@ describe('The applyGridConfig export', () => {
         expect(CLASS_NAMES.TABLE).toEqual(
             'banana-table',
             'the override table class is wrong'
+        );
+
+        expect(USE_GRID_STYLES).toEqual(
+            false
         );
     });
 


### PR DESCRIPTION
Adding override to dis-include grid CSS. By default CSS will be loaded into document as a `style` tag.

````js
applyGridConfig({
    USE_GRID_STYLES: false
});
````

