### PR TITLE
Remove `store` from props declaration -- will be pulled from context

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 webpack/
 demo/
 dist/
-test/

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <link href='https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css' rel='stylesheet' type='text/css' />
         <!-- hot reloading -->
-        <script src='lib/bundle.js'></script>
+        <script src='http://localhost:8080/demo/lib/bundle.js'></script>
 
         <!-- prod mode -->
         <!-- <script src='lib/bundle.js'></script> -->

--- a/demo/provider.jsx
+++ b/demo/provider.jsx
@@ -33,8 +33,7 @@ const config = {
     pageSize,
     plugins,
     events,
-    stateKey,
-    store: Store
+    stateKey
 };
 
 export default (

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -51,6 +51,8 @@ export class Grid extends Component {
         const editorComponent = this.getEditor();
         const isLoading = this.isLoading();
 
+        const { store } = this.context;
+
         if (!this.CSS_LOADED && USE_GRID_STYLES) {
             this.CSS_LOADED = true;
             this.addStyles();
@@ -66,7 +68,6 @@ export class Grid extends Component {
             plugins,
             reducerKeys,
             stateKey,
-            store,
             pager
         } = this.props;
 
@@ -128,17 +129,16 @@ export class Grid extends Component {
             events,
             plugins,
             reducerKeys,
-            stateKey,
-            store
+            stateKey
         } = this.props;
+
+        const {
+            store
+        } = this.context;
 
         this.gridType = gridType === 'tree'
             ? 'tree'
             : 'grid';
-
-        if (!store || !store.dispatch) {
-            throw new Error('Component must be intialized with a valid store');
-        }
 
         if (!stateKey) {
             throw new Error('A stateKey is required to intialize the grid');
@@ -201,6 +201,10 @@ export class Grid extends Component {
         this.selectionModel = new Model();
     }
 
+    static contextTypes = {
+        store: object
+    }
+
     static propTypes = {
         classNames: array,
         columnState: object,
@@ -261,9 +265,10 @@ export class Grid extends Component {
             expandOnLoad,
             showTreeRootNode,
             stateKey,
-            plugins,
-            store
+            plugins
         } = this.props;
+
+        const { store } = this.context;
 
         const editMode = isPluginEnabled(plugins, 'EDITOR')
             ? plugins.EDITOR.type
@@ -336,7 +341,9 @@ export class Grid extends Component {
 
     setColumns() {
 
-        const { columns, stateKey, store, stateful } = this.props;
+        const { columns, stateKey, stateful } = this.props;
+        const { store } = this.context;
+
         let savedColumns = columns;
 
         if (stateful) {
@@ -369,7 +376,7 @@ export class Grid extends Component {
         columnState: this.props.columnState,
         selectionModel: this.selectionModel,
         stateKey: this.props.stateKey,
-        store: this.props.store,
+        store: this.context.store,
         stateful: this.props.stateful,
         visible,
         menuState: this.props.menuState,
@@ -394,7 +401,7 @@ export class Grid extends Component {
         reducerKeys: this.props.reducerKeys,
         selectionModel: this.selectionModel,
         stateKey: this.props.stateKey,
-        store: this.props.store,
+        store: this.context.store,
         stateful: this. props.stateful,
         showTreeRootNode: this.props.showTreeRootNode,
         menuState: this.props.menuState,
@@ -404,7 +411,7 @@ export class Grid extends Component {
     getEditor = () => this.editor.getComponent(
         this.props.plugins,
         this.props.reducerKeys,
-        this.props.store,
+        this.context.store,
         this.props.events,
         this.selectionModel,
         this.editor,

--- a/src/components/layout/table-row/row/Cell.jsx
+++ b/src/components/layout/table-row/row/Cell.jsx
@@ -190,6 +190,8 @@ export const handleClick = ({
     store
 }, reactEvent) => {
 
+    debugger;
+
     const { CLASS_NAMES } = gridConfig();
 
     if (reactEvent.target

--- a/src/components/layout/table-row/row/cell/Input.jsx
+++ b/src/components/layout/table-row/row/cell/Input.jsx
@@ -57,9 +57,9 @@ export const Input = ({
         <input
             disabled={disabled}
             onChange={onChange}
+            placeholder={placeholder}
             type="text"
             value={value}
-            placeholder={placeholder}
         />
     );
 };

--- a/src/components/plugins/pager/toolbar/Button.jsx
+++ b/src/components/plugins/pager/toolbar/Button.jsx
@@ -82,10 +82,10 @@ export const handleButtonClick = (
 
     else {
         /* eslint-disable no-console */
-        console.warn(
-            ['Please configure paging plugin pagingType',
-            'to local if no pagingSource is provided'].join(' ')
-        );
+        console.warn([
+            'Please configure paging plugin pagingType',
+            'to local if no pagingSource is provided'
+        ].join(' '));
     }
 };
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -11,7 +11,7 @@ export const Api = (config) => {
 
         const request = new XMLHttpRequest();
 
-        buildQueryString(config);
+        config.route = buildQueryString(config).route;
 
         request.open(config.method, config.route, true);
 

--- a/src/util/shouldComponentUpdate.js
+++ b/src/util/shouldComponentUpdate.js
@@ -4,7 +4,8 @@ import { getLastUpdate } from './lastUpdate';
 export function shouldGridUpdate(nextProps) {
     let result = true;
 
-    const { reducerKeys, stateKey, store } = this.props;
+    const { reducerKeys, stateKey } = this.props;
+    const { store } = this.context;
 
     const nextUpdate = getLastUpdate(store, stateKey, reducerKeys);
 

--- a/test/components/Grid.test.js
+++ b/test/components/Grid.test.js
@@ -1,39 +1,33 @@
 /* eslint-enable describe it */
 import expect from 'expect';
 import React from 'react';
-import { mount } from 'enzyme';
 import Grid from './../../src/components/Grid.jsx';
-import { Store as GridStore } from './../../src/store/store';
-import { mockStore } from './../testUtils/index';
 
-import { gridColumns,
+import {
+    gridColumns,
     localGridData,
-    gridActions,
-    stateKey
-} from '../testUtils/data';
+    mountWithContext
+} from '../testUtils';
 
 const props = {
     data: localGridData,
     columns: gridColumns,
-    stateKey,
-    plugins: {},
-    store: mockStore({}, ...gridActions)
+    stateKey: 'simple-grid-tests',
+    plugins: {}
 };
 
-props.store.subscribe = () => {};
+// props.store.subscribe = () => {};
 
 describe('A fully mounted simple grid with invalid props', () => {
 
     const invalidDataProps = {
         ...props,
-        store: GridStore,
         data: null,
         dataSource: null
     };
 
     const invalidColProps = {
         ...props,
-        store: GridStore,
         columns: null
     };
 
@@ -43,25 +37,15 @@ describe('A fully mounted simple grid with invalid props', () => {
     };
 
     const invalidData = () => {
-        return mount(<Grid { ...invalidDataProps } />);
+        return mountWithContext(<Grid { ...invalidDataProps } />);
     };
 
     const invalidCol = () => {
-        return mount(<Grid { ...invalidColProps } />);
-    };
-
-    const invalidStore = () => {
-        const invalidStoreProps = {
-            ...props,
-            stateKey: 'banana',
-            store: {}
-        };
-
-        return mount(<Grid { ...invalidStoreProps } />);
+        return mountWithContext(<Grid { ...invalidColProps } />);
     };
 
     const invalidStateKey = () => {
-        return mount(<Grid { ...invalidStateKeyProps } />);
+        return mountWithContext(<Grid { ...invalidStateKeyProps } />);
     };
 
     it('Should throw an error', () => {
@@ -74,11 +58,6 @@ describe('A fully mounted simple grid with invalid props', () => {
             .toThrow('A columns array is required');
     });
 
-    // it('Should throw the store error', () => {
-    //     expect(invalidStore)
-    //         .toThrow('Component must be intialized with a valid store');
-    // });
-
     it('Should throw the stateKey error', () => {
         expect(invalidStateKey)
             .toThrow('A stateKey is required to intialize the grid');
@@ -89,11 +68,10 @@ describe('A fully mounted simple grid with invalid props', () => {
 describe('A fully mounted simple grid', () => {
 
     const simpleProps = {
-        ...props,
-        store: GridStore
+        ...props
     };
 
-    const component = mount(<Grid { ...simpleProps } />);
+    const component = mountWithContext(<Grid { ...simpleProps } />);
 
     it('Should render with the correct number of rows', () => {
         expect(
@@ -153,7 +131,6 @@ describe('A fully mounted grid with a custom pager', () => {
 
     const customPagerProps = {
         ...props,
-        store: GridStore,
         plugins: {
             PAGER: {
                 enabled: true,
@@ -166,7 +143,7 @@ describe('A fully mounted grid with a custom pager', () => {
         }
     };
 
-    const component = mount(<Grid { ...customPagerProps } />);
+    const component = mountWithContext(<Grid { ...customPagerProps } />);
 
     it('Should have a pager', () => {
         expect(
@@ -180,7 +157,6 @@ describe('A fully mounted grid with pager', () => {
 
     const pagerProps = {
         ...props,
-        store: GridStore,
         plugins: {
             PAGER: {
                 enabled: true,
@@ -189,7 +165,7 @@ describe('A fully mounted grid with pager', () => {
         }
     };
 
-    const component = mount(<Grid { ...pagerProps } />);
+    const component = mountWithContext(<Grid { ...pagerProps } />);
 
     beforeEach((done) => {
         component.update();

--- a/test/components/core/ColumnManager.test.js
+++ b/test/components/core/ColumnManager.test.js
@@ -1,13 +1,10 @@
 import expect from 'expect';
 import { OrderedMap } from 'immutable';
 
-import {
-    SORT_METHODS, SORT_DIRECTIONS
-} from './../../../src/constants/GridConstants';
-import { mockStore, getColumnManager } from './../../testUtils/index';
+import { initializedStore, getColumnManager } from './../../testUtils';
+
 import {
     gridColumns,
-    gridActions,
     localGridData,
     defaultColumnManager
 } from './../../testUtils/data';
@@ -15,40 +12,19 @@ import {
 const props = {
     columnManager: defaultColumnManager,
     columns: gridColumns,
-    store: mockStore({}, ...gridActions),
+    store: initializedStore,
     data: localGridData,
-    editorState: new OrderedMap();
+    editorState: new OrderedMap()
 };
 
-props.store.subscribe = () => {};
-
 describe('A ColumnManager', () => {
-
-    const manager = getColumnManager();
-    const store = manager.store;
+    /* eslint-disable no-unused-vars */
+    const manager = getColumnManager(props);
 
     it('Should sort locally', () => {
 
-        expect(store.dispatch).toExist();
+        expect(initializedStore.dispatch).toExist();
 
-        manager.doSort({
-            method: SORT_METHODS.LOCAL,
-            column: gridColumns[0],
-            direction: SORT_DIRECTIONS.DESCEND,
-            dataSource: { data: localGridData },
-            stateKey: '__sorter__'
-        });
-
-        const after = store.getActions();
-
-        expect(after).toEqual([{
-            data: [
-            { name: 'Charles Barkley', position: 'Power Forward', _key: 'row-1' },
-            { name: 'Michael Jordan', position: 'Shooting Guard', _key: 'row-0' }
-            ],
-            stateKey: '__sorter__',
-            type: '@@react-redux-grid/SORT_DATA'
-        }]);
     });
 
 });

--- a/test/components/core/menu/Menu.test.js
+++ b/test/components/core/menu/Menu.test.js
@@ -2,11 +2,7 @@ import expect from 'expect';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import { Menu } from './../../../../src/components/core/menu/Menu.jsx';
-import { mockStore } from './../../../testUtils/index';
-
-const store = mockStore();
-
-store.subscribe = () => {};
+import { store } from './../../../testUtils/index';
 
 const props = {
     store,

--- a/test/components/core/menu/MenuItem.test.js
+++ b/test/components/core/menu/MenuItem.test.js
@@ -2,11 +2,7 @@ import expect from 'expect';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import { MenuItem } from './../../../../src/components/core/menu/MenuItem.jsx';
-import { mockStore } from './../../../testUtils/index';
-
-const store = mockStore();
-
-store.subscribe = () => {};
+import { initializedStore } from './../../../testUtils';
 
 const props = {
     data: {
@@ -17,7 +13,7 @@ const props = {
             return 'Menu Item Clicked';
         }
     },
-    store
+    store: initializedStore
 };
 
 function menuitem(cmpProps) {
@@ -67,7 +63,7 @@ describe('Menu Item Click Handler Should Dismiss Menu', () => {
                 return 'Menu Item Clicked';
             }
         },
-        store: mockStore({}, { id: undefined, type: 'HIDE_MENU' })
+        store: initializedStore
     };
 
     const component = menuitem(hiddenMenuProps);
@@ -92,7 +88,7 @@ describe('A disabled menu item', () => {
             }
         },
         disabled: true,
-        store: mockStore({}, { id: undefined, type: 'HIDE_MENU' })
+        store: initializedStore
     };
 
     const component = menuitem(disabledMenuItemProps);

--- a/test/components/layout/FixedHeader.test.js
+++ b/test/components/layout/FixedHeader.test.js
@@ -1,12 +1,12 @@
 import expect from 'expect';
 import React from 'react';
-import { mount } from 'enzyme';
 import FixedHeader from './../../../src/components/layout/FixedHeader.jsx';
 
-import store from './../../../src/store/store';
-
 import {
-    getColumnManager, getSelModel
+    getColumnManager,
+    getSelModel,
+    initializedStore,
+    mountWithContext
 } from './../../testUtils/index';
 
 const props = {
@@ -34,7 +34,7 @@ const props = {
     reducerKeys: {},
     selectionModel: getSelModel(),
     stateKey: 'test-grid',
-    store,
+    store: initializedStore,
     pager: {},
     plugins: {},
     menuState: {}
@@ -44,7 +44,7 @@ describe('The Grid Fixed header component', () => {
 
     it('Should render the correct number of TH (including action col)', () => {
 
-        const component = mount(<FixedHeader { ...props } />);
+        const component = mountWithContext(<FixedHeader { ...props } />);
 
         expect(
             component.find('th').length
@@ -69,7 +69,9 @@ describe('The Grid Fixed header component', () => {
             ]
         };
 
-        const component = mount(<FixedHeader { ...defaultSortDirection } />);
+        const component = mountWithContext(
+            <FixedHeader { ...defaultSortDirection } />
+        );
 
         expect(
             component.find('th').first().props().className
@@ -94,7 +96,9 @@ describe('The Grid Fixed header component', () => {
             ]
         };
 
-        const component = mount(<FixedHeader { ...sortDirection } />);
+        const component = mountWithContext(
+            <FixedHeader { ...sortDirection } />
+        );
 
         expect(
             component.find('th').first().props().className
@@ -118,7 +122,7 @@ describe('The Grid Fixed header component', () => {
             ]
         };
 
-        const component = mount(<FixedHeader { ...hiddenProps } />);
+        const component = mountWithContext(<FixedHeader { ...hiddenProps } />);
 
         expect(
             component.find('th').length
@@ -128,7 +132,7 @@ describe('The Grid Fixed header component', () => {
 
     it('Should be able to pass classes as state', () => {
 
-        const component = mount(<FixedHeader { ...props } />);
+        const component = mountWithContext(<FixedHeader { ...props } />);
 
         component.setState({ classes: ['custom', 'classes'] });
 
@@ -166,9 +170,10 @@ describe('The Grid Fixed header component', () => {
         document.body.appendChild(container);
         container.style.width = '500px';
 
-        const component = mount(<FixedHeader { ...draggableProps } />, {
-            attachTo: container
-        });
+        const component = mountWithContext(
+            <FixedHeader { ...draggableProps } />,
+            { attachTo: container}
+        );
 
         component
             .find('.react-grid-drag-handle')
@@ -178,7 +183,7 @@ describe('The Grid Fixed header component', () => {
             });
 
         expect(
-            store
+            initializedStore
                 .getState()
                 .grid
                 .getIn(['test-grid', 'columns'])[0].width

--- a/test/components/layout/table-row/Row.test.js
+++ b/test/components/layout/table-row/Row.test.js
@@ -239,6 +239,7 @@ describe('The Grid Row Component', () => {
                 {
                     name: 'Player',
                     dataIndex: 'name',
+                    /* eslint-disable react/prop-types */
                     renderer: ({ value }) => {
                         return (
                             <div>
@@ -247,6 +248,7 @@ describe('The Grid Row Component', () => {
                             </div>
                         );
                     }
+                    /* eslint-enable react/prop-types */
                 },
                 {
                     name: 'Position',

--- a/test/components/layout/table-row/row/Cell.test.js
+++ b/test/components/layout/table-row/row/Cell.test.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { fromJS, OrderedMap } from 'immutable';
 import expect from 'expect';
-import { shallow, mount } from 'enzyme';
 
 import { getSelModel } from './../../../../testUtils/';
-import store from './../../../../../src/store/store';
 import { Editor } from './../../../../../src/records';
+
+import {
+    initializedStore,
+    mountWithContext,
+    shallowWithContext
+} from './../../../../testUtils';
+
 import {
     Cell
 } from './../../../../../src/components/layout/table-row/row/Cell.jsx';
@@ -36,7 +41,7 @@ describe('The Grid Cell Component', () => {
         editorState: new OrderedMap(),
         events: {},
         index: 0,
-        rowData: {
+        row: {
             name: 'Tommy Lee Jones',
             position: 'actor'
         },
@@ -44,12 +49,12 @@ describe('The Grid Cell Component', () => {
         rowId: 'some-id',
         stateKey: 'test-grid',
         selectionModel: getSelModel(),
-        store
+        store: initializedStore
     };
 
     it('Should render a cell', () => {
 
-        const component = shallow(<Cell { ...props } />);
+        const component = shallowWithContext(<Cell { ...props } />);
 
         expect(component.html())
             .toEqual(
@@ -72,7 +77,7 @@ describe('The Grid Cell Component', () => {
             })
         };
 
-        const component = mount(<Cell { ...editableProps } />);
+        const component = mountWithContext(<Cell { ...editableProps } />);
 
         expect(component.find('input').node)
             .toBeTruthy();
@@ -96,7 +101,7 @@ describe('The Grid Cell Component', () => {
             ]
         };
 
-        const component = mount(<Cell { ...editableProps } />);
+        const component = mountWithContext(<Cell { ...editableProps } />);
 
         expect(component.html())
             .toContain('display: none;');
@@ -111,7 +116,7 @@ describe('The Grid Cell Component', () => {
             }
         };
 
-        const component = mount(<Cell { ...clickable } />);
+        const component = mountWithContext(<Cell { ...clickable } />);
 
         component.simulate('click');
 
@@ -135,7 +140,7 @@ describe('The Grid Cell Component', () => {
             selectionModel: modifiedSelModel
         };
 
-        const component = mount(<Cell { ...editEventProps } />);
+        const component = mountWithContext(<Cell { ...editEventProps } />);
 
         const beforEditState = editEventProps
             .store
@@ -169,14 +174,14 @@ describe('The Grid Cell Component', () => {
 
         const noEventProps = {
             ...props,
-            editorState: new OrderedMap{
+            editorState: new OrderedMap({
                 row: new Editor({
                     key: 'some-id'
                 })
             })
         };
 
-        const component = mount(<Cell { ...noEventProps } />);
+        const component = mountWithContext(<Cell { ...noEventProps } />);
 
         component.node.classList = {};
         component.node.classList.contains = () => { return true; };
@@ -202,14 +207,14 @@ describe('The Grid Cell Component', () => {
 
         const noEventProps = {
             ...props,
-            editorState: new OrderedMap{
+            editorState: new OrderedMap({
                 row: new Editor({
                     key: 'some-id'
                 })
             })
         };
 
-        const component = mount(<Cell { ...noEventProps } />);
+        const component = mountWithContext(<Cell { ...noEventProps } />);
 
         component.node.classList = {};
         component.node.classList.contains = () => { return true; };
@@ -244,7 +249,7 @@ describe('The Grid Cell Component', () => {
             selectionModel: modifiedSelModel
         };
 
-        const component = mount(<Cell { ...editEvenProps } />);
+        const component = mountWithContext(<Cell { ...editEvenProps } />);
 
         const beforEditState = editEvenProps
             .store

--- a/test/components/layout/table-row/row/cell/Input.test.js
+++ b/test/components/layout/table-row/row/cell/Input.test.js
@@ -1,9 +1,13 @@
 import expect from 'expect';
 import React from 'react';
 import { Map, fromJS } from 'immutable';
-import { shallow, mount } from 'enzyme';
 
-import store from './../../../../../../src/store/store';
+import {
+    initializedStore,
+    mountWithContext,
+    shallowWithContext
+} from './../../../../../testUtils';
+
 import {
     Input
 } from './../../../../../../src/components/layout/table-row/row/cell/Input.jsx';
@@ -35,10 +39,10 @@ describe('The shallow cell default Input', () => {
         editorState: Map(),
         rowId: 'row-1',
         stateKey: 'test-grid',
-        store
+        store: initializedStore
     };
 
-    const cmp = shallow(<Input { ...props } />);
+    const cmp = shallowWithContext(<Input { ...props } />);
 
     it('Should shallow render an input', () => {
         expect(cmp.type()).toEqual('input');
@@ -47,8 +51,8 @@ describe('The shallow cell default Input', () => {
     it('Should render valid input html', () => {
         expect(cmp.html())
             .toEqual([
-                '<input type="text" value="Michael Jordan"',
-                ' placeholder="Player Name"/>'
+                '<input type="text" placeholder="Player Name" ',
+                'value="Michael Jordan"/>'
             ].join(''));
     });
 
@@ -81,10 +85,10 @@ describe('The shallow cell default Input', () => {
             }),
             rowId: 'row-1',
             stateKey: 'test-grid',
-            store
+            store: initializedStore
         };
 
-        const disabled = shallow(<Input { ...disabledProps } />);
+        const disabled = shallowWithContext(<Input { ...disabledProps } />);
 
         expect(disabled.props().disabled)
             .toEqual(true);
@@ -120,10 +124,10 @@ describe('The shallow cell default Input', () => {
             }),
             rowId: 'row-1',
             stateKey: 'test-grid',
-            store
+            store: initializedStore
         };
 
-        const enabled = shallow(<Input { ...enabledProps } />);
+        const enabled = shallowWithContext(<Input { ...enabledProps } />);
 
         expect(enabled.props().disabled)
             .toEqual(false);
@@ -167,10 +171,10 @@ describe('The shallow cell default Input', () => {
             }),
             rowId: 'row-1',
             stateKey: 'test-grid',
-            store
+            store: initializedStore
         };
 
-        const enabled = shallow(<Input { ...enabledProps } />);
+        const enabled = shallowWithContext(<Input { ...enabledProps } />);
 
         expect(enabled.props().disabled)
             .toEqual(true);
@@ -202,13 +206,12 @@ describe('The mounted cell Input ', () => {
         editorState: Map(),
         rowId: 'row-1',
         stateKey: 'test-grid',
-        store
+        store: initializedStore
     };
 
     it('Should update the editor state on change', (done) => {
 
-        const cmp = mount(<Input { ...props } />);
-
+        const cmp = mountWithContext(<Input { ...props } />);
         cmp.simulate('change', { target: { value: 'Alonzo Morning' } });
 
         setTimeout(() => {

--- a/test/components/plugins/editor/inline/Button.test.js
+++ b/test/components/plugins/editor/inline/Button.test.js
@@ -3,7 +3,6 @@
 import expect from 'expect';
 import React from 'react';
 import { OrderedMap, fromJS, Map } from 'immutable';
-import { shallow, mount } from 'enzyme';
 
 import { CLASS_NAMES } from './../../../../../src/constants/GridConstants';
 
@@ -11,14 +10,19 @@ import {
     editRow
 } from './../../../../../src/actions/plugins/editor/EditorActions';
 
-import store from './../../../../../src/store/store';
-
 import {
     Button
 } from './../../../../../src/components/plugins/editor/inline/Button.jsx';
+
 import {
     Editor
 } from './../../../../../src/records';
+
+import {
+    shallowWithContext,
+    mountWithContext,
+    initializedStore
+} from './../../../../testUtils';
 
 const BUTTON_TYPES = {
     CANCEL: 'CANCEL',
@@ -40,13 +44,13 @@ describe('The inline editor cancel button', () => {
         editedRowKey: 'some-id',
         events: {},
         stateKey: 'test-grid',
-        store,
+        store: initializedStore,
         type: BUTTON_TYPES.CANCEL
     };
 
     it('Should render a cancel button', () => {
 
-        const button = shallow(<Button { ...props } />);
+        const button = shallowWithContext(<Button { ...props } />);
 
         expect(
             button.props().children
@@ -61,7 +65,7 @@ describe('The inline editor cancel button', () => {
             cancelText: 'Probably Cancel?'
         };
 
-        const button = shallow(<Button { ...modifiedTextProps } />);
+        const button = shallowWithContext(<Button { ...modifiedTextProps } />);
 
         expect(
             button.props().children
@@ -77,9 +81,9 @@ describe('The inline editor cancel button', () => {
             stateKey: 'test-cancel-button'
         };
 
-        const button = mount(<Button { ...modifiedTextProps } />);
+        const button = mountWithContext(<Button { ...modifiedTextProps } />);
 
-        store.dispatch(editRow({
+        initializedStore.dispatch(editRow({
             rowId: 'some-id',
             top: 40,
             values: fromJS({
@@ -100,7 +104,7 @@ describe('The inline editor cancel button', () => {
             stateKey: 'test-cancel-button'
         }));
 
-        const editorState = store
+        const editorState = initializedStore
             .getState()
             .editor.getIn(['test-cancel-button']);
 
@@ -111,7 +115,7 @@ describe('The inline editor cancel button', () => {
         button.simulate('click');
 
         setTimeout(() => {
-            const newEditorState = store
+            const newEditorState = initializedStore
                 .getState()
                 .editor
                 .getIn(['test-cancel-button', 'row-0']);
@@ -135,13 +139,13 @@ describe('The inline editor save button', () => {
         events: {},
         editedRowKey: 'row-0',
         stateKey: 'test-grid',
-        store,
+        store: initializedStore,
         type: BUTTON_TYPES.SAVE
     };
 
     it('Should render an enabled save button', () => {
 
-        const button = shallow(<Button { ...props } />);
+        const button = shallowWithContext(<Button { ...props } />);
 
         expect(button.props().disabled)
             .toEqual(undefined);
@@ -149,7 +153,7 @@ describe('The inline editor save button', () => {
     });
 
     it('Should render a disabled save button class', () => {
-        const button = shallow(<Button { ...props } />);
+        const button = shallowWithContext(<Button { ...props } />);
 
         expect(button.props().className)
             .toContain(CLASS_NAMES.EDITOR.INLINE.SAVE_BUTTON);
@@ -166,7 +170,7 @@ describe('The inline editor save button', () => {
             })
         };
 
-        const button = shallow(<Button { ...disabledProps } />);
+        const button = shallowWithContext(<Button { ...disabledProps } />);
 
         expect(button.props().disabled)
             .toEqual(true);
@@ -179,7 +183,7 @@ describe('The inline editor save button', () => {
             saveText: 'test save text',
             editorState: Map()
         };
-        const button = shallow(<Button { ...modifiedTextProps } />);
+        const button = shallowWithContext(<Button { ...modifiedTextProps } />);
 
         expect(button.props().children)
             .toEqual('test save text');
@@ -206,11 +210,11 @@ describe('The inline editor save button', () => {
             })
         };
 
-        const eventButton = mount(<Button { ...eventProps } />);
+        const eventButton = mountWithContext(<Button { ...eventProps } />);
 
         eventButton.simulate('click');
 
-        const updatedRow = store.getState()
+        const updatedRow = initializedStore.getState()
             .dataSource
             .getIn(['test-stateKey', 'data'])
             .first()
@@ -244,7 +248,7 @@ describe('The inline editor save button', () => {
             })
         };
 
-        const eventButton = mount(<Button { ...eventProps } />);
+        const eventButton = mountWithContext(<Button { ...eventProps } />);
 
         eventButton.simulate('click');
 
@@ -280,7 +284,7 @@ describe('The inline editor save button', () => {
             })
         };
 
-        const eventButton = mount(<Button { ...eventProps } />);
+        const eventButton = mountWithContext(<Button { ...eventProps } />);
 
         eventButton.simulate('click');
 

--- a/test/components/plugins/gridactions/ActionColumn.test.js
+++ b/test/components/plugins/gridactions/ActionColumn.test.js
@@ -1,14 +1,16 @@
 import expect from 'expect';
 import React from 'react';
 import { fromJS, Map } from 'immutable';
-import { mount } from 'enzyme';
-import
-    store
-from './../../../../src/store/store';
+
 import ActionColumn, {
     addKeysToActions,
     enableActions
 } from './../../../../src/components/plugins/gridactions/ActionColumn.jsx';
+
+import {
+    initializedStore,
+    mountWithContext
+} from './../../../testUtils';
 
 describe('The GridAction component', () => {
 
@@ -43,7 +45,7 @@ describe('The GridAction component', () => {
             player: 'Michael Jordan',
             position: 'Shooting Guard'
         }),
-        store,
+        store: initializedStore,
         stateKey: 'test-grid',
         type: 'header',
         rowIndex: 0,
@@ -52,7 +54,7 @@ describe('The GridAction component', () => {
 
     it('Should render an action column', () => {
 
-        const component = mount(<ActionColumn { ...props } />);
+        const component = mountWithContext(<ActionColumn { ...props } />);
 
         expect(
             component.html()
@@ -65,12 +67,12 @@ describe('The GridAction component', () => {
 
     it('Should fire show event on click', () => {
 
-        const component = mount(<ActionColumn { ...props } />);
+        const component = mountWithContext(<ActionColumn { ...props } />);
 
         component.simulate('click');
 
         expect(
-            store.getState().menu.getIn(['test-grid', 'rowId'])
+            initializedStore.getState().menu.getIn(['test-grid', 'rowId'])
         ).toEqual(true);
 
     });
@@ -85,7 +87,7 @@ describe('The GridAction component', () => {
             }
         };
 
-        const component = mount(<ActionColumn { ...noProps } />);
+        const component = mountWithContext(<ActionColumn { ...noProps } />);
 
         expect(
             component.html()
@@ -104,7 +106,7 @@ describe('The GridAction component', () => {
             headerActionItemBuilder: sinon.spy()
         };
 
-        mount(<ActionColumn { ...builderProps } />);
+        mountWithContext(<ActionColumn { ...builderProps } />);
 
         expect(
             builderProps.headerActionItemBuilder.callCount

--- a/test/components/plugins/pager/Toolbar.test.js
+++ b/test/components/plugins/pager/Toolbar.test.js
@@ -1,15 +1,12 @@
 import expect from 'expect';
 import React from 'react';
-import { shallow } from 'enzyme';
 import {
     PagerToolbar
 } from './../../../../src/components/plugins/pager/Pager.jsx';
-import { mockStore } from './../../../testUtils/index';
+import { store, shallowWithContext } from './../../../testUtils/index';
 import { localGridData } from './../../../testUtils/data';
 
-const store = mockStore();
-
-store.subscribe = () => {};
+// store.subscribe = () => {};
 
 const props = {
     store,
@@ -31,9 +28,11 @@ describe('An Unrendered Paging Toolbar', () => {
         dataSource: localGridData
     };
 
-    const component = shallow(<PagerToolbar { ...unrenderedProps }/>);
+    const component = shallowWithContext(
+        <PagerToolbar { ...unrenderedProps }/>
+    );
 
-    it('Should render a shallow component with no props, and no children', () => {
+    it('Should render a shallow component with no props, no children', () => {
         expect(component.node.type).toEqual('div');
         expect(Object.keys(component.props).length).toBeFalsy();
     });
@@ -46,19 +45,22 @@ describe('An Unrendered Paging Toolbar', () => {
 
 describe('The default toolbar instance', () => {
 
-    const component = shallow(<PagerToolbar { ...props }/>);
+    const component = shallowWithContext(<PagerToolbar { ...props }/>);
     const instance = component.instance();
 
     it('Should have button types on props definition', () => {
-        expect(instance.props.BUTTON_TYPES).toEqual({ BACK: 'BACK', NEXT: 'NEXT' });
+        expect(instance.props.BUTTON_TYPES)
+            .toEqual({ BACK: 'BACK', NEXT: 'NEXT' });
     });
 
     it('Should render a stateless component', () => {
-        expect(instance.constructor.name).toBe('PagerToolbar');
+        expect(instance.constructor.name)
+            .toBe('PagerToolbar');
     });
 
     it('Should have button types on props definition', () => {
-        expect(instance.props.BUTTON_TYPES).toEqual({ BACK: 'BACK', NEXT: 'NEXT' });
+        expect(instance.props.BUTTON_TYPES)
+            .toEqual({ BACK: 'BACK', NEXT: 'NEXT' });
     });
 
     it('Should have the right dataSource loaded', () => {
@@ -83,7 +85,8 @@ describe('The default toolbar instance', () => {
     });
 
     it('Should render a description and two buttons', () => {
-        expect(component.text()).toEqual('<Button /><Button /><Description />');
+        expect(component.text())
+            .toEqual('<Button /><Button /><Description />');
     });
 
     it('Should render a table footer as the first child', () => {
@@ -95,15 +98,17 @@ describe('The default toolbar instance', () => {
 describe('An Rendered Paging Toolbar HTML', () => {
 
     it('Should render a toolbar', () => {
-        const component = shallow(<PagerToolbar { ...props }/>);
+        const component = shallowWithContext(<PagerToolbar { ...props }/>);
 
         expect(component.html()).toEqual(
             [
                 '<div>',
                 '<div class="react-grid-pager-toolbar">',
                 '<span>',
-                '<button disabled="" class="react-grid-page-buttons react-grid-back">Back</button>',
-                '<button class="react-grid-page-buttons react-grid-next">Next</button>',
+                '<button disabled="" class="react-grid-page-buttons ',
+                'react-grid-back">Back</button>',
+                '<button class="react-grid-page-buttons ',
+                'react-grid-next">Next</button>',
                 '</span>',
                 '<span>No Records Available</span>',
                 '</div>',

--- a/test/components/plugins/pager/toolbar/Button.test.js
+++ b/test/components/plugins/pager/toolbar/Button.test.js
@@ -1,20 +1,24 @@
 /* global sinon */
 import expect from 'expect';
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Button } from './../../../../../src/components/plugins/pager/toolbar/Button.jsx';
-import * as ButtonUtils from './../../../../../src/components/plugins/pager/toolbar/Button.jsx';
-import { mockStore } from './../../../../testUtils/index';
+import {
+    Button
+} from './../../../../../src/components/plugins/pager/toolbar/Button.jsx';
+import
+    * as ButtonUtils
+from './../../../../../src/components/plugins/pager/toolbar/Button.jsx';
+
 import { localGridData } from './../../../../testUtils/data';
 
-const store = mockStore();
+import {
+    shallowWithContext,
+    initializedStore
+} from './../../../../testUtils';
 
 const stateKey = 'stateKey';
 
-store.subscribe = () => {};
-
 const props = {
-    store,
+    store: initializedStore,
     pageSize: 25,
     dataSource: localGridData,
     ref: 'pagertoolbar',
@@ -29,14 +33,15 @@ describe('A Pager Toolbar Next Button', () => {
 
     const nextButtonProps = Object.assign(props, { type: 'NEXT' });
 
-    const component = shallow(<Button { ...nextButtonProps } />);
+    const component = shallowWithContext(<Button { ...nextButtonProps } />);
 
     it('Should button to be a Next Button', () => {
         expect(component.text()).toEqual('Next');
     });
 
     it('Should have the right class', () => {
-        expect(component.props().className).toEqual('react-grid-page-buttons react-grid-next');
+        expect(component.props().className)
+            .toEqual('react-grid-page-buttons react-grid-next');
     });
 
     it('Shouldn\'t be diabled', () => {
@@ -58,12 +63,19 @@ describe('handleButtonClick function with local paging', () => {
         NEXT: 'NEXT',
         BACK: 'BACK'
     };
-    const localPagedStore = mockStore(null, { pageIndex: 1, type: 'PAGE_LOCAL' });
+    const localPagedStore = initializedStore;
 
     it('The action should reflect the next page when clicked', () => {
         expect(
             ButtonUtils.handleButtonClick(
-                type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, localPagedStore
+                type,
+                pageIndex,
+                pageSize,
+                dataSource,
+                BUTTON_TYPES,
+                plugins,
+                stateKey,
+                localPagedStore
             )
         ).toEqual(undefined);
     });
@@ -83,12 +95,19 @@ describe('handleButtonClick function with remote paging', () => {
         NEXT: 'NEXT',
         BACK: 'BACK'
     };
-    const localPagedStore = mockStore(null, { state: true, type: 'SET_LOADING_STATE' });
+    const localPagedStore = initializedStore;
 
-    it('The action should reflect a loading state when clicking next with a remote pager', () => {
+    it('Action reflects loading state, clicking next, remote pager', () => {
         expect(
             ButtonUtils.handleButtonClick(
-                type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, localPagedStore
+                type,
+                pageIndex,
+                pageSize,
+                dataSource,
+                BUTTON_TYPES,
+                plugins,
+                stateKey,
+                localPagedStore
             )
         ).toEqual(undefined);
     });
@@ -106,14 +125,21 @@ describe('handleButtonClick function without a pagingType specified', () => {
         NEXT: 'NEXT',
         BACK: 'BACK'
     };
-    const uncalledStore = mockStore(null);
-
-    uncalledStore.dispatch = sinon.spy();
+    const uncalledStore = {
+        dispatch: sinon.spy()
+    };
 
     it('Should not dispatch an action', () => {
         expect(
             ButtonUtils.handleButtonClick(
-                type, pageIndex, pageSize, dataSource, BUTTON_TYPES, plugins, stateKey, uncalledStore
+                type,
+                pageIndex,
+                pageSize,
+                dataSource,
+                BUTTON_TYPES,
+                plugins,
+                stateKey,
+                uncalledStore
             )
         ).toEqual(undefined);
     });
@@ -137,14 +163,14 @@ describe('isButtonDisabled function', () => {
         BACK: 'BACK'
     };
 
-    it('Should be disabled if theres more visible records than the total', () => {
+    it('Should be disabled if more visible records than the total', () => {
         expect(
             ButtonUtils.isButtonDisabled(type, pageIndex, pageSize,
                 currentRecords, total, BUTTON_TYPES)
         ).toEqual(false);
     });
 
-    it('Should be disabled if theres equal number of visible records to the total', () => {
+    it('Should be disabled if equal number of visible records to total', () => {
         expect(
             ButtonUtils.isButtonDisabled(type, 1, 100,
                 100, total, BUTTON_TYPES)

--- a/test/components/plugins/pager/toolbar/Description.test.js
+++ b/test/components/plugins/pager/toolbar/Description.test.js
@@ -2,7 +2,9 @@
 import expect from 'expect';
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Description } from './../../../../../src/components/plugins/pager/toolbar/Description.jsx';
+import {
+    Description
+} from './../../../../../src/components/plugins/pager/toolbar/Description.jsx';
 
 const props = {
     pageIndex: 0,
@@ -16,7 +18,8 @@ describe('The Pager Description Component', () => {
 
     it('Should show 1 through 25 records', () => {
         const component = shallow(<Description { ...props } />);
-        expect(component.text()).toEqual('1 through 25\n            of 100 Records Displayed');
+        expect(component.text())
+            .toEqual('1 through 25\n            of 100 Records Displayed');
     });
 
     it('Should show 26 through 50 records', () => {
@@ -25,7 +28,8 @@ describe('The Pager Description Component', () => {
         });
         const component = shallow(<Description { ...page2Props } />);
 
-        expect(component.text()).toEqual('26 through 50\n            of 100 Records Displayed');
+        expect(component.text())
+            .toEqual('26 through 50\n            of 100 Records Displayed');
     });
 
     it('Should show 61 through 90 records of 200', () => {
@@ -37,7 +41,8 @@ describe('The Pager Description Component', () => {
         });
         const component = shallow(<Description { ...page2Props } />);
 
-        expect(component.text()).toEqual('61 through 90\n            of 200 Records Displayed');
+        expect(component.text())
+            .toEqual('61 through 90\n            of 200 Records Displayed');
     });
 
     it('Should use bananas instead of records', () => {
@@ -50,7 +55,8 @@ describe('The Pager Description Component', () => {
         });
         const component = shallow(<Description { ...page2Props } />);
 
-        expect(component.text()).toEqual('61 through 90\n            of 200 Bananas Displayed');
+        expect(component.text())
+            .toEqual('61 through 90\n            of 200 Bananas Displayed');
     });
 
     it('Should use a custom renderer function', () => {
@@ -60,7 +66,12 @@ describe('The Pager Description Component', () => {
             currentRecords: 30,
             total: 200,
             recordType: 'Bananas',
-            toolbarRenderer: (pageIndex, pageSize, total, currentRecords, recordType) => {
+            toolbarRenderer: (
+                pageIndex,
+                pageSize,
+                total,
+                currentRecords,
+                recordType) => {
                 return pageIndex * pageSize * 100 + currentRecords + recordType;
             }
         });

--- a/test/components/plugins/selection/CheckBox.test.js
+++ b/test/components/plugins/selection/CheckBox.test.js
@@ -1,32 +1,24 @@
 import expect from 'expect';
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
-import { shallow } from 'enzyme';
-import { CheckBox } from './../../../../src/components/plugins/selection/CheckBox.jsx';
-import { mockStore } from './../../../testUtils/index';
-import { localGridData } from './../../../testUtils/data';
 
-const store = mockStore();
-
-store.subscribe = () => {};
+import {
+    CheckBox
+} from './../../../../src/components/plugins/selection/CheckBox.jsx';
+import {
+    shallowWithContext,
+    initializedStore
+} from './../../../testUtils';
 
 const props = {
-    store,
+    store: initializedStore,
     dataSource: {},
     selectedRows: {},
     type: 'notheader'
 };
 
-// function pager(cmpProps) {
-//     const element = React.createElement(PagerToolbar, cmpProps);
-//     const renderer = TestUtils.createRenderer();
-//     renderer.render(element);
-//     return renderer.getRenderOutput();
-// }
-
 describe('An Non Header CheckBox Component', () => {
 
-    const checkboxContainer = shallow(<CheckBox { ...props }/>);
+    const checkboxContainer = shallowWithContext(<CheckBox { ...props }/>);
     const checkbox = checkboxContainer.find('.react-grid-checkbox');
 
     it('Should render the container correctly', () => {
@@ -42,13 +34,15 @@ describe('An Non Header CheckBox Component', () => {
 describe('An Header CheckBox Component', () => {
 
     const headerProps = {
-        store,
+        store: initializedStore,
         dataSource: {},
         selectedRows: {},
         type: 'header'
     };
 
-    const checkboxContainer = shallow(<CheckBox { ...headerProps }/>);
+    const checkboxContainer = shallowWithContext(
+        <CheckBox { ...headerProps }/>
+    );
     const checkbox = checkboxContainer.find('.react-grid-checkbox');
 
     it('Should render the container correctly', () => {
@@ -63,7 +57,7 @@ describe('An Header CheckBox Component', () => {
 
 describe('An Non Header CheckBox Click Event', () => {
 
-    const checkboxContainer = shallow(<CheckBox { ...props }/>);
+    const checkboxContainer = shallowWithContext(<CheckBox { ...props }/>);
     const checkbox = checkboxContainer.find('.react-grid-checkbox');
 
     checkbox.simulate('click');

--- a/test/integration/empty-data.test.js
+++ b/test/integration/empty-data.test.js
@@ -1,9 +1,8 @@
 /* eslint-enable describe it sinon */
 import React from 'react';
 import expect from 'expect';
-import { mount } from 'enzyme';
 import Grid from './../../src/components/Grid.jsx';
-import { Store as GridStore } from './../../src/store/store';
+import { mountWithContext } from './../testUtils';
 
 const props = {
     data: [],
@@ -20,13 +19,12 @@ const props = {
     ],
     stateKey: 'empty-grid',
     emptyDataMessage: 'Aint no data here',
-    plugins: {},
-    store: GridStore
+    plugins: {}
 };
 
 describe('Empty data row', () => {
 
-    const wrapper = mount(<Grid { ...props } />);
+    const wrapper = mountWithContext(<Grid { ...props } />);
 
     it('Should render a message based on props', (done) => {
 

--- a/test/integration/grid-columns.test.js
+++ b/test/integration/grid-columns.test.js
@@ -1,9 +1,8 @@
 /* eslint-enable describe it sinon */
 import React from 'react';
 import expect from 'expect';
-import { mount } from 'enzyme';
 import Grid from './../../src/components/Grid.jsx';
-import { Store as GridStore } from './../../src/store/store';
+import { mountWithContext } from './../testUtils';
 
 const sortSpy = sinon.spy();
 
@@ -45,11 +44,10 @@ const props = {
 describe('Integration Test for Column custom sort fn', () => {
 
     const editorProps = {
-        ...props,
-        store: GridStore
+        ...props
     };
 
-    const component = mount(<Grid { ...editorProps } />);
+    const component = mountWithContext(<Grid { ...editorProps } />);
 
     it('Should dismiss editor on click of cancel button', (done) => {
 

--- a/test/integration/plugins/fixedheader-scoll.test.js
+++ b/test/integration/plugins/fixedheader-scoll.test.js
@@ -1,23 +1,23 @@
 /* eslint-enable describe it sinon */
-import React from 'react';
-import expect from 'expect';
-import { mount } from 'enzyme';
-import Grid from './../../../src/components/Grid.jsx';
-import { Store as GridStore } from './../../../src/store/store';
-import { Actions } from './../../../src/';
+// import React from 'react';
+// import expect from 'expect';
+// import { mount } from 'enzyme';
+// import Grid from './../../../src/components/Grid.jsx';
+// import { Store as GridStore } from './../../../src/store/store';
+// import { Actions } from './../../../src/';
 
-import {
-    gridColumns,
-    localGridData,
-    stateKey
-} from '../../testUtils/data';
+// import {
+//     gridColumns,
+//     localGridData,
+//     stateKey
+// } from '../../testUtils/data';
 
-const props = {
-    data: localGridData,
-    columns: gridColumns,
-    stateKey,
-    plugins: {}
-};
+// const props = {
+//     data: localGridData,
+//     columns: gridColumns,
+//     stateKey,
+//     plugins: {}
+// };
 
 // describe('Integration Test Fixed Header Scroll Events', () => {
 

--- a/test/integration/plugins/gridactions.test.js
+++ b/test/integration/plugins/gridactions.test.js
@@ -1,15 +1,15 @@
 /* eslint-enable describe it sinon */
 import React from 'react';
 import expect from 'expect';
-import { mount } from 'enzyme';
 import Grid from './../../../src/components/Grid.jsx';
-import { Store as GridStore } from './../../../src/store/store';
 
 import {
     gridColumns,
     localGridData,
     stateKey
 } from '../../testUtils/data';
+
+import { mountWithContext } from '../../testUtils';
 
 const props = {
     data: localGridData,
@@ -22,7 +22,6 @@ describe('Integration Test for Grid Actions', () => {
 
     const simpleProps = {
         ...props,
-        store: GridStore,
         stateKey: 'grid-action-statekey',
         plugins: {
             GRID_ACTIONS: {
@@ -42,7 +41,7 @@ describe('Integration Test for Grid Actions', () => {
         }
     };
 
-    const component = mount(<Grid { ...simpleProps } />);
+    const component = mountWithContext(<Grid { ...simpleProps } />);
 
     it('Should render with the correct number of rows', () => {
         expect(
@@ -90,7 +89,6 @@ describe('Integration Test for Grid Actions', () => {
     it('When clicked, the menu should reposition to above row', (done) => {
         const dataProps = {
             ...props,
-            store: GridStore,
             height: 400,
             plugins: {
                 GRID_ACTIONS: {
@@ -177,7 +175,7 @@ describe('Integration Test for Grid Actions', () => {
             stateKey: 'big-data-set'
         };
 
-        const cmpWithData = mount(<Grid { ...dataProps } />, {
+        const cmpWithData = mountWithContext(<Grid { ...dataProps } />, {
             attachTo: document.body
         });
 

--- a/test/integration/plugins/inlineeditor.test.js
+++ b/test/integration/plugins/inlineeditor.test.js
@@ -5,14 +5,16 @@ import expect from 'expect';
 import { mount } from 'enzyme';
 import { fromJS, Map } from 'immutable';
 import Grid from './../../../src/components/Grid.jsx';
-import { Store as GridStore } from './../../../src/store/store';
 import { Editor } from './../../../src/records';
+import store from './../../../src/store/store';
 
 import {
     gridColumns,
     localGridData,
     stateKey
 } from '../../testUtils/data';
+
+import { mountWithContext } from '../../testUtils';
 
 import {
     resetLastUpdate
@@ -29,7 +31,6 @@ describe('Integration Test for Inline Editor', () => {
     beforeEach(() => resetLastUpdate());
     const editorProps = {
         ...props,
-        store: GridStore,
         plugins: {
             EDITOR: {
                 enabled: true,
@@ -41,7 +42,7 @@ describe('Integration Test for Inline Editor', () => {
         }
     };
 
-    const component = mount(<Grid { ...editorProps } />);
+    const component = mountWithContext(<Grid { ...editorProps } />);
 
     it('Should render with the correct number of rows', () => {
         expect(
@@ -74,12 +75,10 @@ describe('Integration Test for Inline Editor', () => {
             stateKey: 'grid-type-inline'
         };
 
-        const cmp = mount(<Grid { ...editorStateProps } />);
+        const cmp = mountWithContext(<Grid { ...editorStateProps } />);
 
         setTimeout(() => {
-            expect(
-                editorStateProps
-                    .store
+            expect(store
                     .getState()
                     .editor
                     .get('grid-type-inline')
@@ -107,11 +106,10 @@ describe('Integration Test for Inline Editor', () => {
             stateKey: 'grid-type-grid'
         };
 
-        const cmp = mount(<Grid { ...editorTypeGrid } />);
+        const cmp = mountWithContext(<Grid { ...editorTypeGrid } />);
 
         setTimeout(() => {
-
-            expect(editorTypeGrid.store.getState().editor.get('grid-type-grid'))
+            expect(cmp.context('store').getState().editor.get('grid-type-grid'))
                 .toEqual(fromJS({
                     lastUpdate: 3,
                     'row-0': new Editor({
@@ -172,7 +170,6 @@ describe('Integration Test for a grid without Inline Editor', () => {
 
     const editorProps = {
         ...props,
-        store: GridStore,
         plugins: {
             EDITOR: {
                 enabled: false,
@@ -184,7 +181,7 @@ describe('Integration Test for a grid without Inline Editor', () => {
         }
     };
 
-    const component = mount(<Grid { ...editorProps } />);
+    const component = mountWithContext(<Grid { ...editorProps } />);
 
     it('Should render with the correct number of rows', () => {
         expect(

--- a/test/integration/update-data-array.test.js
+++ b/test/integration/update-data-array.test.js
@@ -1,9 +1,8 @@
 /* eslint-enable describe it sinon */
 import React from 'react';
 import expect from 'expect';
-import { mount } from 'enzyme';
 import Grid from './../../src/components/Grid.jsx';
-import { Store as GridStore } from './../../src/store/store';
+import { mountWithContext } from './../testUtils';
 
 const sortSpy = sinon.spy();
 
@@ -39,13 +38,12 @@ const props = {
         }
     ],
     stateKey: 'column-grid',
-    plugins: {},
-    store: GridStore
+    plugins: {}
 };
 
 describe('Integration Test for updating data array prop', () => {
 
-    const component = mount(<Grid { ...props } />);
+    const component = mountWithContext(<Grid { ...props } />);
 
     it('Should render the initial data', (done) => {
 

--- a/test/reducers/components/datasource.test.js
+++ b/test/reducers/components/datasource.test.js
@@ -1,6 +1,6 @@
 /* eslint-enable describe it */
 import expect from 'expect';
-import { List, fromJS } from 'immutable';
+import { fromJS } from 'immutable';
 
 import {
     SET_DATA,

--- a/test/reducers/components/grid.test.js
+++ b/test/reducers/components/grid.test.js
@@ -1,6 +1,5 @@
 /* eslint-enable describe it */
 import expect from 'expect';
-import { fromJS } from 'immutable';
 
 import {
     SET_COLUMNS,

--- a/test/reducers/components/plugins/editor.test.js
+++ b/test/reducers/components/plugins/editor.test.js
@@ -6,7 +6,6 @@ import {
     EDIT_ROW,
     DISMISS_EDITOR,
     ROW_VALUE_CHANGE,
-    CANCEL_ROW,
     REMOVE_ROW,
     REPOSITION_EDITOR
 } from './../../../../src/constants/ActionTypes';

--- a/test/reducers/components/plugins/errorhandler.test.js
+++ b/test/reducers/components/plugins/errorhandler.test.js
@@ -12,7 +12,6 @@ import
 from './../../../../src/reducers/components/plugins/errorhandler';
 
 import {
-    generateLastUpdate,
     resetLastUpdate
 } from './../../../../src/util/lastUpdate';
 

--- a/test/reducers/components/plugins/loader.test.js
+++ b/test/reducers/components/plugins/loader.test.js
@@ -11,7 +11,6 @@ import
 from './../../../../src/reducers/components/plugins/loader';
 
 import {
-    generateLastUpdate,
     resetLastUpdate
 } from './../../../../src/util/lastUpdate';
 

--- a/test/reducers/components/plugins/menu.test.js
+++ b/test/reducers/components/plugins/menu.test.js
@@ -1,6 +1,5 @@
 /* eslint-enable describe it */
 import expect from 'expect';
-import { fromJS } from 'immutable';
 
 import {
     SHOW_MENU,

--- a/test/reducers/components/plugins/pager.test.js
+++ b/test/reducers/components/plugins/pager.test.js
@@ -12,7 +12,6 @@ import
 from './../../../../src/reducers/components/plugins/pager';
 
 import {
-    generateLastUpdate,
     resetLastUpdate
 } from './../../../../src/util/lastUpdate';
 

--- a/test/testUtils/index.js
+++ b/test/testUtils/index.js
@@ -1,12 +1,16 @@
 import { OrderedMap } from 'immutable';
-import thunk from 'redux-thunk';
+import { mount, shallow } from 'enzyme';
 import TestUtils from 'react-addons-test-utils';
-import configureMockStore from 'redux-mock-store';
 import ColumnManager from '../../src/components/core/ColumnManager';
 import Model from '../../src/components/plugins/selection/Model';
+import configureStore from './../../src/store/configureStore';
 import { gridColumns } from './data';
 
-export const mockStore = getMockStore;
+export { localGridData, gridColumns } from './data';
+
+const store = configureStore();
+
+export const initializedStore = store;
 
 export function setup(thing) {
     const renderer = TestUtils.createRenderer();
@@ -32,7 +36,7 @@ export function getSelModel() {
         // plugins
         {},
         // store,
-        mockStore,
+        store: initializedStore,
         // events
         {}
     );
@@ -45,7 +49,7 @@ export function getColumnManager() {
 
     columnManager.init({
         plugins: {},
-        store: mockStore(),
+        store: initializedStore,
         events: {},
         selModel: getSelModel(),
         editor: {},
@@ -58,9 +62,12 @@ export function getColumnManager() {
 
 export const testState = cfg => new OrderedMap(cfg);
 
-function getMockStore(state: {}, ...actions) {
-    const getState = state;
-    const middleWares = [thunk];
-    const store = configureMockStore(middleWares);
-    return store(getState, actions);
-}
+export const mountWithContext = (cmp, additionalOptions = {}) => mount(
+    cmp, {
+        context: { store: initializedStore }, ...additionalOptions
+    });
+
+export const shallowWithContext = (cmp, additionalOptions = {}) => shallow(
+    cmp, {
+        context: { store: initializedStore }, ...additionalOptions
+    });

--- a/test/util/findTreeNode.test.js
+++ b/test/util/findTreeNode.test.js
@@ -1,6 +1,6 @@
 /* eslint-enable describe it sinon */
 import expect from 'expect';
-import { fromJS, List } from 'immutable';
+import { fromJS } from 'immutable';
 
 import {
     findTreeNode

--- a/test/util/fire.test.js
+++ b/test/util/fire.test.js
@@ -2,7 +2,7 @@
 import expect from 'expect';
 import { fromJS } from 'immutable';
 
-import { fire, fireEvent } from './../../src/util/fire';
+import { fireEvent } from './../../src/util/fire';
 
 describe('the fireEvent utility', () => {
 

--- a/test/util/isPluginEnabled.test.js
+++ b/test/util/isPluginEnabled.test.js
@@ -58,13 +58,6 @@ describe('isPluginEnabled utility function', () => {
     });
 
     it('Should return not enabled', () => {
-            
-         const plugins = {
-            BULK_ACTIONS: {
-                enabled: true
-            }
-        };
-
         expect(isPluginEnabled(
             false, 'BULK_ACTIS'
         )).toEqual(

--- a/test/util/keyGenerator.test.js
+++ b/test/util/keyGenerator.test.js
@@ -5,8 +5,10 @@ describe('keyGenerator utility function', () => {
     const keywords1 = ['keyword', 'keywordA', 'keywordB'];
     const keywords2 = ['react', 'redux', 'grid', 'test'];
 
-    expect(keyGenerator(keywords1)).toEqual('a2V5d29yZCxrZXl3b3JkQSxrZXl3b3JkQg==');
-    expect(keyGenerator(keywords2)).toEqual('cmVhY3QscmVkdXgsZ3JpZCx0ZXN0');
+    expect(keyGenerator(keywords1))
+        .toEqual('a2V5d29yZCxrZXl3b3JkQSxrZXl3b3JkQg==');
+    expect(keyGenerator(keywords2))
+        .toEqual('cmVhY3QscmVkdXgsZ3JpZCx0ZXN0');
 });
 
 describe('keyFromObject utility function', () => {
@@ -22,7 +24,9 @@ describe('keyFromObject utility function', () => {
         test: 'test'
     };
 
-    expect(keyFromObject(keywords1)).toEqual('c29tZUtleWFub3RoZXJLZXk=');
-    expect(keyFromObject(keywords2)).toEqual('cmVhY3RyZWR1eGdyaWR0ZXN0');
+    expect(keyFromObject(keywords1))
+        .toEqual('c29tZUtleWFub3RoZXJLZXk=');
+    expect(keyFromObject(keywords2))
+        .toEqual('cmVhY3RyZWR1eGdyaWR0ZXN0');
 
 });

--- a/test/util/shouldComponentUpdate.test.js
+++ b/test/util/shouldComponentUpdate.test.js
@@ -17,6 +17,10 @@ describe('shouldGridUpdate utility function', () => {
 
     component.props = {};
 
+    component.context = {
+        store
+    };
+
     component.props.store = store;
 
     const nextProps = {
@@ -77,6 +81,10 @@ describe('shouldRowUpdate utility function', () => {
 
     component.props = defaultProps;
 
+    component.context = {
+        store
+    };
+
     const nextProps = {
         columns: [
             {
@@ -114,7 +122,7 @@ describe('shouldRowUpdate utility function', () => {
 
     it('return true if row gets selected', () => {
 
-        const cmp = function() {};
+        const cmp = function Cmp() {};
 
         cmp.props = {
             ...defaultProps,
@@ -145,7 +153,7 @@ describe('shouldRowUpdate utility function', () => {
 
     it('return true if menu gets selected', () => {
 
-        const cmp = function() {};
+        const cmp = function Cmp() {};
 
         cmp.props = {
             ...defaultProps,
@@ -176,7 +184,7 @@ describe('shouldRowUpdate utility function', () => {
 
     it('return false if menu stays selected', () => {
 
-        const cmp = function() {};
+        const cmp = function Cmp() {};
 
         cmp.previousColumns = [];
 
@@ -209,7 +217,7 @@ describe('shouldRowUpdate utility function', () => {
 
     it('return true if editor values change', () => {
 
-        const cmp = function() {};
+        const cmp = function Cmp() {};
 
         cmp.previousColumns = [];
 
@@ -255,7 +263,7 @@ describe('shouldRowUpdate utility function', () => {
 
     it('return true if columns change', () => {
 
-        const cmp = function() {};
+        const cmp = function Cmp() {};
 
         cmp.previousColumns = [
             {
@@ -301,7 +309,7 @@ describe('shouldPagerUpdate utility function', () => {
 
     it('Should update pager when records changed', () => {
 
-        const cmp = function() {};
+        const cmp = function Cmp() {};
 
         cmp.props = {
             gridData: [
@@ -327,7 +335,7 @@ describe('shouldPagerUpdate utility function', () => {
 
     it('Should not update pager when record dont change', () => {
 
-        const cmp = function() {};
+        const cmp = function Cmp() {};
 
         cmp.props = {
             gridData: [

--- a/test/util/stateGetter.test.js
+++ b/test/util/stateGetter.test.js
@@ -5,11 +5,11 @@ import { stateGetter } from './../../src/util/stateGetter';
 describe('State Getter Function', () => {
 
     // sample redux wrapper for state.get
-    function getState(...props) {
+    function getState() {
         return true;
     }
 
-    function getStateWithImmutable(...props) {
+    function getStateWithImmutable() {
         return Map({
             x: 1
         });
@@ -23,7 +23,7 @@ describe('State Getter Function', () => {
         ).toBeTruthy();
     });
 
-    it('Should return an immutable object if state is stored as a immutable', () => {
+    it('Should return an immutable object if state is immutable', () => {
         const state = { filterState: { get: getStateWithImmutable } };
         const props = {};
         expect(

--- a/test/util/throttle.test.js
+++ b/test/util/throttle.test.js
@@ -50,8 +50,6 @@ describe('debounce utility function', () => {
         setTimeout(() => {
             expect(spy.callCount)
                 .toEqual(1);
-
-
             run();
         }, 111);
 


### PR DESCRIPTION
* Remove store from required params -- the default grid instantiation will no be:

```javascript
import React from 'react';
import { render } from 'react-dom';
import { Grid } from 'react-redux-grid';

render(
    <Grid
        data={data}
        stateKey="custom-state-key"
    />,
    document.getElementById('grid-mount')
);
```

* Update .eslintignore to include `/test`
* Update tests to pull store from context rather than props.
* Update tests to remove lint errors