### PR TITLE
feat(row): added a row renderer via plugin

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -370,9 +370,6 @@ export const plugins = {
 |:---------|:------------|:--------------|
 | enabled|bool|whether the bulk action toolbar should be used|
 | renderer | func | function which returns the row contents for this row|
-| rowProps | object | properties for this row. For example `className`, `onClick`, ...  |
-| cells | object | the cells rendered by the column renderer  |
-| row | object | the map containing all the row data |
 
 
 ## Events

--- a/README.MD
+++ b/README.MD
@@ -350,6 +350,31 @@ export const plugins = {
 | enabled|bool|whether the bulk action toolbar should be used|
 | actions|arrayOf(object)|the actions (including button text, and event handler) that will be displayed in the bar|
 
+
+## Row renderer
+```javascript
+export const plugins = {
+    ROW: {
+        enabled: true,
+        renderer: ({rowProps, cells, row}) => {
+          return (
+              <tr { ...rowProps }>
+                  { cells }
+              </tr>
+            );
+        }
+    }
+};
+```
+| Prop|Type|Description|
+|:---------|:------------|:--------------|
+| enabled|bool|whether the bulk action toolbar should be used|
+| renderer | func | function which returns the row contents for this row|
+| rowProps | object | properties for this row. For example `className`, `onClick`, ...  |
+| cells | object | the cells rendered by the column renderer  |
+| row | object | the map containing all the row data |
+
+
 ## Events
 
 All grid events are passed in as a single object.

--- a/src/components/layout/table-row/Row.jsx
+++ b/src/components/layout/table-row/Row.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
+import { isPluginEnabled } from '../../../util/isPluginEnabled';
 
 import { Cell } from './row/Cell';
 import { EmptyCell } from './row/EmptyCell';
@@ -155,18 +156,27 @@ export class Row extends Component {
 
         addEmptyInsert(cells, visibleColumns, plugins);
 
-        const rowEl = (
-            <tr { ...rowProps }>
-                { cells }
-            </tr>
+        let rowEl;
+
+        if (isPluginEnabled(plugins, 'ROW') &&
+          typeof plugins.ROW.renderer === 'function') {
+        	// super important that we pass rowProps and cells
+        	// since the user is almost certainly going to want both
+        	// lets make sure this gets documented
+            rowEl = plugins.ROW.renderer({ rowProps, cells, row });
+        } else {
+            rowEl = (
+                <tr { ...rowProps }>
+                    { cells }
+                </tr>
             );
+        }
 
         if (dragAndDrop) {
             return connectDragSource(connectDropTarget(rowEl));
         }
 
         return rowEl;
-
     }
 
     constructor(props) {

--- a/test/components/layout/table-row/Row.test.js
+++ b/test/components/layout/table-row/Row.test.js
@@ -231,7 +231,7 @@ describe('The Grid Row Component', () => {
 
     });
 
-    it('Should render a row with a custom renderer', () => {
+    it('Should render a row with a custom column renderer', () => {
 
         const dynamicEditProps = {
             ...props,
@@ -266,6 +266,45 @@ describe('The Grid Row Component', () => {
         );
 
     });
+
+    // it('Should render a row with a custom row renderer', () => {
+    //     const dynamicEditProps = {
+    //         ...props,
+    //         row: fromJS({
+    //             name: 'Michael Jordan',
+    //             position: 'Shooting Guard',
+    //             _key: 'row-0',
+    //             header: true
+    //         }),
+    //         plugins: {
+    //             ROW: {
+    //                 enabled: true,
+    //                 renderer: ({rowProps, cells, row}) => {
+    //                     if (row.get('header')) {
+    //                         rowProps.className =
+    //                             `${rowProps.className} HeaderRowClass`;
+    //                         return (
+    //                             <tr { ...rowProps }>
+    //                                 { cells }
+    //                             </tr>
+    //                         );
+    //                     }
+    //                     return (
+    //                         <tr { ...rowProps}>
+    //                             { cells }
+    //                         </tr>
+    //                     );
+    //                 }
+    //             }
+    //         }
+    //     };
+    //     const component = mount(<Row { ...dynamicEditProps } />);
+    //     expect(
+    //         component.first('tr').class
+    //     ).toEqual(
+    //         'react-grid-row HeaderRowClass'
+    //     );
+    // });
 
     it('Should fire custom row click event', () => {
 

--- a/test/components/layout/table-row/Row.test.js
+++ b/test/components/layout/table-row/Row.test.js
@@ -267,44 +267,46 @@ describe('The Grid Row Component', () => {
 
     });
 
-    // it('Should render a row with a custom row renderer', () => {
-    //     const dynamicEditProps = {
-    //         ...props,
-    //         row: fromJS({
-    //             name: 'Michael Jordan',
-    //             position: 'Shooting Guard',
-    //             _key: 'row-0',
-    //             header: true
-    //         }),
-    //         plugins: {
-    //             ROW: {
-    //                 enabled: true,
-    //                 renderer: ({rowProps, cells, row}) => {
-    //                     if (row.get('header')) {
-    //                         rowProps.className =
-    //                             `${rowProps.className} HeaderRowClass`;
-    //                         return (
-    //                             <tr { ...rowProps }>
-    //                                 { cells }
-    //                             </tr>
-    //                         );
-    //                     }
-    //                     return (
-    //                         <tr { ...rowProps}>
-    //                             { cells }
-    //                         </tr>
-    //                     );
-    //                 }
-    //             }
-    //         }
-    //     };
-    //     const component = mount(<Row { ...dynamicEditProps } />);
-    //     expect(
-    //         component.first('tr').class
-    //     ).toEqual(
-    //         'react-grid-row HeaderRowClass'
-    //     );
-    // });
+    it('Should render a row with a custom rowRenderer', () => {
+        const dynamicEditProps = {
+            ...props,
+            row: fromJS({
+                name: 'Michael Jordan',
+                position: 'Shooting Guard',
+                _key: 'row-0',
+                header: true
+            }),
+            plugins: {
+                ROW: {
+                    enabled: true,
+                    /* eslint-disable react/prop-types */
+                    renderer: ({ rowProps, cells }) => {
+                        rowProps.className = `${rowProps.className} custom`;
+                        return (
+                            <tr { ...rowProps}>
+                                { cells }
+                            </tr>
+                        );
+                    }
+                    /* eslint-enable react/prop-types */
+                }
+            }
+        };
+
+        const component = mount(<Row { ...dynamicEditProps } />);
+
+        expect(
+            component.first('tr').hasClass('custom')
+        ).toEqual(
+            true
+        );
+
+        expect(
+            component.first('tr').hasClass('react-grid-row')
+        ).toEqual(
+            true
+        );
+    });
 
     it('Should fire custom row click event', () => {
 


### PR DESCRIPTION
Hi Benjamin,

now the renderer is called via plugin method. I also started to add a test for it. But the row.test.js is not called and it is the first time I work with react and had a few problems to fix some lint errors in the test. Currently the test is commented Row.test.js in line 270.