### PR TITLE
bug/pager - DISMISS_EDITOR, REMOVE_ROW, and ADD_NEW_ROW now set total correctly

### DIFF
--- a/src/reducers/actionHelpers/datasource.js
+++ b/src/reducers/actionHelpers/datasource.js
@@ -74,9 +74,8 @@ export const dismissEditor = (state, { stateKey }) => {
     if (previousData
         && previousProxy
         && previousData.size > previousProxy.size) {
-        previousTotal = previousProxy.size;
+        previousTotal = previousTotal - 1;
     }
-
     const record = state.get(stateKey);
 
     if (record) {
@@ -84,8 +83,8 @@ export const dismissEditor = (state, { stateKey }) => {
             data: previousProxy,
             proxy: previousProxy,
             currentRecords: previousProxy,
-            total: previousTotal,
             isEditing: false,
+            total: previousTotal,
             lastUpdate: generateLastUpdate()
         });
 
@@ -96,16 +95,26 @@ export const dismissEditor = (state, { stateKey }) => {
 };
 
 export const removeRow = (state, { stateKey, rowIndex }) => {
+    const existingState = state.get(stateKey);
+    const currentTotal = existingState.get('total');
+
     const remainingRows = state
         .getIn([stateKey, 'data'])
         .remove(rowIndex || 0, 1);
 
     const record = state.get(stateKey);
 
+    const updatedTotal = existingState
+        && currentTotal
+        && currentTotal > 0
+        ? currentTotal - 1
+        : 0;
+
     const updated = record.merge({
         data: remainingRows,
         proxy: remainingRows,
         currentRecords: remainingRows,
+        total: updatedTotal,
         lastUpdate: generateLastUpdate()
     });
 
@@ -160,17 +169,23 @@ export const addNewRow = (state, { rowId, stateKey, rowIndex }) => {
         data = new List();
     }
 
-    rowIndex = rowIndex ===undefined
+    const updatedTotal = existingState
+        && existingState.get('total')
+        ? existingState.get('total')
+        : 0;
+
+    rowIndex = rowIndex === undefined
         ? 0
         : rowIndex;
 
     const newData = data.insert(rowIndex, newRow);
+
     const updated = existingState.merge({
         data: newData,
         proxy: data,
         isEditing: true,
-        lastUpdate: generateLastUpdate(),
-        total: newData.size
+        total: updatedTotal + 1,
+        lastUpdate: generateLastUpdate()
     });
 
     return state.setIn([stateKey], updated);
@@ -245,7 +260,7 @@ export const setTreeNodeVisibility = (state, {
     return state.setIn([stateKey], updated);
 };
 
-export const saveRow = (state, { rowIndex, stateKey, values}) => {
+export const saveRow = (state, { rowIndex, stateKey, values }) => {
     const data = state
         .getIn([stateKey, 'data'])
         .set(rowIndex, fromJS(values));

--- a/test/reducers/components/datasource.test.js
+++ b/test/reducers/components/datasource.test.js
@@ -223,6 +223,54 @@ describe('The grid dataSource reducer dissmissEditor func', () => {
             dataSource(inState, action)
         ).toEqualImmutable(outState);
     });
+
+    it('Should decrement and maintain total if proxy less values than data',
+        () => {
+            const inState = fromJS({
+                'test-grid': {
+                    data: [
+                        { cell: 1 },
+                        { cell: 2 },
+                        { cell: 3 }
+
+                    ],
+                    proxy: [
+                        { cell: 1 },
+                        { cell: 2 }
+                    ],
+                    total: 151
+                }
+            });
+
+            const outState = fromJS({
+                'test-grid': {
+                    proxy: [
+                        { cell: 1 },
+                        { cell: 2 }
+                    ],
+                    total: 150,
+                    data: [
+                        { cell: 1 },
+                        { cell: 2 }
+                    ],
+                    currentRecords: [
+                        { cell: 1 },
+                        { cell: 2 }
+                    ],
+                    isEditing: false,
+                    lastUpdate: 1
+                }
+            });
+
+            const action = {
+                stateKey: 'test-grid',
+                type: DISMISS_EDITOR
+            };
+
+            expect(
+                dataSource(inState, action)
+            ).toEqualImmutable(outState);
+        });
 });
 
 describe('The grid dataSource reducer removeRow func', () => {
@@ -260,7 +308,7 @@ describe('The grid dataSource reducer removeRow func', () => {
                 currentRecords: [
                     { cell: 2 }
                 ],
-                total: 2,
+                total: 1,
                 lastUpdate: 1
             }
         });
@@ -288,7 +336,7 @@ describe('The grid dataSource reducer removeRow func', () => {
                 currentRecords: [
                     { cell: 1 }
                 ],
-                total: 2,
+                total: 1,
                 lastUpdate: 1
             }
         });
@@ -301,6 +349,107 @@ describe('The grid dataSource reducer removeRow func', () => {
 
         expect(
             dataSource(inState, action)
+        ).toEqualImmutable(outState);
+
+    });
+
+    it('Should default total to 0 when inState total is 0', () => {
+
+        const customInState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: [],
+                total: 0,
+                lastUpdate: 1
+            }
+        });
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: [],
+                total: 0,
+                lastUpdate: 1
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            rowIndex: 1,
+            type: REMOVE_ROW
+        };
+
+        expect(
+            dataSource(customInState, action)
+        ).toEqualImmutable(outState);
+
+    });
+
+    it('Should default total to 0 when total not provided', () => {
+
+        const customInState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: [],
+                lastUpdate: 1
+            }
+        });
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: [],
+                total: 0,
+                lastUpdate: 1
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            rowIndex: 1,
+            type: REMOVE_ROW
+        };
+
+        expect(
+            dataSource(customInState, action)
+        ).toEqualImmutable(outState);
+
+    });
+
+    it('Should default total to 0 when total provided is negative', () => {
+
+        const customInState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: [],
+                total: -1,
+                lastUpdate: 1
+            }
+        });
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: [],
+                total: 0,
+                lastUpdate: 1
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            rowIndex: 1,
+            type: REMOVE_ROW
+        };
+
+        expect(
+            dataSource(customInState, action)
         ).toEqualImmutable(outState);
 
     });
@@ -359,6 +508,88 @@ describe('The grid dataSource reducer addRow func', () => {
 
         expect(
             dataSource(inState, action)
+        ).toEqualImmutable(outState);
+    });
+
+    it('Should add a new row and maintain total if multiple pages', () => {
+        const customInState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                currentRecords: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                total: 150
+            }
+        });
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                data: [
+                    { cell: '', _key: 'row-0' },
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                currentRecords: [
+                    { cell: 1 },
+                    { cell: 2 }
+                ],
+                total: 151,
+                isEditing: true,
+                lastUpdate: 1
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            rowId: 'row-0',
+            type: ADD_NEW_ROW
+        };
+
+        expect(
+            dataSource(customInState, action)
+        ).toEqualImmutable(outState);
+    });
+
+    it('Should add a new row and + 1 to total when no total on inState', () => {
+        const customInState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [],
+                currentRecords: []
+            }
+        });
+
+        const outState = fromJS({
+            'test-grid': {
+                proxy: [],
+                data: [{_key: 'row-0'}],
+                currentRecords: [],
+                total: 1,
+                isEditing: true,
+                lastUpdate: 1
+            }
+        });
+
+        const action = {
+            stateKey: 'test-grid',
+            rowId: 'row-0',
+            type: ADD_NEW_ROW
+        };
+
+        expect(
+            dataSource(customInState, action)
         ).toEqualImmutable(outState);
     });
 


### PR DESCRIPTION
Fix for bug #132.

Feedback Requested: I moved the logic for updating total from addNewRows and dismissEditor to saveRow so the grid totals update on save. I can see arguments for either.

Note: tests are currently failing due to moving the logic, will update after getting feedback