### PR TITLE
State getter should return state when it is nested in an immutable object

### DIFF
--- a/docs/USING_GRID_REDUCERS.md
+++ b/docs/USING_GRID_REDUCERS.md
@@ -109,7 +109,7 @@ If you want to hide grid reducers from the root of your state:
 
 ````js
 import { combineReducers } from 'redux';
-import { GridRootReducer } from 'react-redux-grid';
+import { rootReducer } from 'react-redux-grid';
 
 import myAppReducer from './customReducers/app';
 import myDataReducer from './customReducers/data';
@@ -117,7 +117,7 @@ import myDataReducer from './customReducers/data';
 export const rootReducer = combineReducers({
     myAppReducer,
     myDataReducer,
-    nested: GridRootReducer
+    nested: rootReducer
 });
 
 export default rootReducer;

--- a/docs/USING_GRID_REDUCERS.md
+++ b/docs/USING_GRID_REDUCERS.md
@@ -109,7 +109,7 @@ If you want to hide grid reducers from the root of your state:
 
 ````js
 import { combineReducers } from 'redux';
-import { rootReducer } from 'react-redux-grid';
+import { Reducers as rootReducer } from 'react-redux-grid';
 
 import myAppReducer from './customReducers/app';
 import myDataReducer from './customReducers/data';

--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -12,7 +12,9 @@ export const stateGetter = (state, props, key, entry) => {
 
     if (props && props.reducerKeys) {
         if (typeof props.reducerKeys === 'string') {
-            return get(state[props.reducerKeys], key, entry);
+            const nestedInImmutable = typeof state.get === 'function';
+            const nestedState = nestedInImmutable ? state.get(props.reducerKeys) : state[props.reducerKeys];
+            return get(nestedState , key, entry);
         }
         else if (typeof props.reducerKeys === 'object'
             && Object.keys(props.reducerKeys).length > 0

--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -13,8 +13,8 @@ export const stateGetter = (state, props, key, entry) => {
     if (props && props.reducerKeys) {
         if (typeof props.reducerKeys === 'string') {
             const nestedInImmutable = typeof state.get === 'function';
-            const nestedState = nestedInImmutable 
-                ? state.get(props.reducerKeys) 
+            const nestedState = nestedInImmutable
+                ? state.get(props.reducerKeys)
                 : state[props.reducerKeys];
             return get(nestedState , key, entry);
         }

--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -13,7 +13,9 @@ export const stateGetter = (state, props, key, entry) => {
     if (props && props.reducerKeys) {
         if (typeof props.reducerKeys === 'string') {
             const nestedInImmutable = typeof state.get === 'function';
-            const nestedState = nestedInImmutable ? state.get(props.reducerKeys) : state[props.reducerKeys];
+            const nestedState = nestedInImmutable 
+                ? state.get(props.reducerKeys) 
+                : state[props.reducerKeys];
             return get(nestedState , key, entry);
         }
         else if (typeof props.reducerKeys === 'object'

--- a/test/util/stateGetter.test.js
+++ b/test/util/stateGetter.test.js
@@ -106,6 +106,22 @@ describe('State Getter Function', () => {
         }));
     });
 
+    it(['Should return state when it is nested in an immutable object ',
+        'and has immutable state'].join(''), () => {
+        const state = Map({
+            nested: { filterState: { get: getStateWithImmutable } }
+        });
+
+        const props = {
+            reducerKeys: 'nested'
+        };
+        expect(
+            stateGetter(state, props, 'filterState', 'someProp')
+        ).toEqual(Map({
+            x: 1
+        }));
+    });
+
     it('Should return null if state is nested and not registered', () => {
         const state = { nested: {} };
         const props = {


### PR DESCRIPTION
If your entire redux state in Immutable you ran into problems when nesting the grid-reducers in a separate reducerKey. The StateGetter was in the assumption that the parent object is always a plain Object. With this pull-request it is also possible nest your grid reducers in an Immutable object.

Now this works:

```js
import { combineReducers } from 'redux-immutable';
import { Reducers } from 'react-redux-grid';

const gridReducers = combineReducers(Reducers);

const reducers = {
    app: appReducers,
    grid: gridReducers
};

const store = createStore(
    combineReducers(reducers),
    Immutable.Map(initialState),
    compose(applyMiddleware(thunk, promise))
);
```

...also fixed a wrongly named export in the docs