### PR TITLE
Added will-change: transform to prevent repaints on scroll

### DIFF
--- a/src/style/components/tablecontainer.styl
+++ b/src/style/components/tablecontainer.styl
@@ -6,3 +6,4 @@
     overflow-x hidden
     overflow-y auto
     position relative
+    will-change: transform

--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -16,7 +16,7 @@ export const stateGetter = (state, props, key, entry) => {
             const nestedState = nestedInImmutable
                 ? state.get(props.reducerKeys)
                 : state[props.reducerKeys];
-            return get(nestedState , key, entry);
+            return get(nestedState, key, entry);
         }
         else if (typeof props.reducerKeys === 'object'
             && Object.keys(props.reducerKeys).length > 0


### PR DESCRIPTION
- Added will-change: transform to table-container to prevent repaints when scrolling the grid in Chrome, Firefox, and Opera. This change causes slightly more memory usage but provides smoother scrolling with a large number of records; was maintaining 60fps with 2,000 records.

- We could look at adding something like "transform: translateZ(0)" to help with Safari but it's not really a proper usage

- Fixed an existing linting error