### PR TITLE
Fix PropTypes warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "array-from": "^2.1.1",
     "deep-equal": "^1.0.1",
     "immutable": "^3.8.1",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-dnd": "^2.2.4",
     "react-dnd-html5-backend": "^2.1.2",

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import deepEqual from 'deep-equal';
 

--- a/src/components/core/menu/Menu.jsx
+++ b/src/components/core/menu/Menu.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { MenuItem } from './MenuItem';

--- a/src/components/core/menu/MenuItem.jsx
+++ b/src/components/core/menu/MenuItem.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { prefix } from '../../../util/prefix';
 import { emptyFn } from '../../../util/emptyFn';
@@ -42,12 +43,12 @@ class MenuItem extends Component {
     }
 
     static propTypes = {
-        data: React.PropTypes.object,
-        disabled: React.PropTypes.bool,
-        menuItemsTypes: React.PropTypes.object,
-        metaData: React.PropTypes.object,
-        stateKey: React.PropTypes.string,
-        store: React.PropTypes.object
+        data: PropTypes.object,
+        disabled: PropTypes.bool,
+        menuItemsTypes: PropTypes.object,
+        metaData: PropTypes.object,
+        stateKey: PropTypes.string,
+        store: PropTypes.object
     };
 
     static defaultProps = {

--- a/src/components/layout/FixedHeader.jsx
+++ b/src/components/layout/FixedHeader.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 import { Column } from './header/Column';

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Column } from './header/Column';
 import { EmptyHeader } from './header/EmptyHeader';

--- a/src/components/layout/TableContainer.jsx
+++ b/src/components/layout/TableContainer.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 import { gridConfig } from './../../constants/GridConstants';

--- a/src/components/layout/TableRow.jsx
+++ b/src/components/layout/TableRow.jsx
@@ -1,5 +1,6 @@
+import PropTypes from 'prop-types';
 /* eslint-disable react/no-set-state */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { List } from 'immutable';
 import ReactDOM from 'react-dom';
 import { DragDropContext } from 'react-dnd';

--- a/src/components/layout/header/Column.jsx
+++ b/src/components/layout/header/Column.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { DragHandle } from './column/DragHandle';
 import { SortHandle } from './column/SortHandle';

--- a/src/components/layout/header/EmptyHeader.jsx
+++ b/src/components/layout/header/EmptyHeader.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export const EmptyHeader = props => {
 

--- a/src/components/layout/header/column/DragHandle.jsx
+++ b/src/components/layout/header/column/DragHandle.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export const DragHandle = ({ dragAndDropManager, handleDrag }) => (
     <span

--- a/src/components/layout/header/column/SortHandle.jsx
+++ b/src/components/layout/header/column/SortHandle.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { prefix } from './../../../../util/prefix';
 import { gridConfig } from './../../../../constants/GridConstants';

--- a/src/components/layout/header/column/Text.jsx
+++ b/src/components/layout/header/column/Text.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { prefix } from './../../../../util/prefix';
 import { keyFromObject } from './../../../../util/keyGenerator';

--- a/src/components/layout/row/PlaceHolder.jsx
+++ b/src/components/layout/row/PlaceHolder.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { prefix } from '../../../util/prefix';
 import { gridConfig } from '../../../constants/GridConstants';

--- a/src/components/layout/table-row/Row.jsx
+++ b/src/components/layout/table-row/Row.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import { isPluginEnabled } from '../../../util/isPluginEnabled';

--- a/src/components/layout/table-row/row/Cell.jsx
+++ b/src/components/layout/table-row/row/Cell.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Editor } from './cell/Editor';
 import { prefix } from '../../../../util/prefix';

--- a/src/components/layout/table-row/row/PlaceHolder.jsx
+++ b/src/components/layout/table-row/row/PlaceHolder.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { prefix } from '../../../../util/prefix';
 import { gridConfig } from '../../../../constants/GridConstants';

--- a/src/components/layout/table-row/row/RowContainer.jsx
+++ b/src/components/layout/table-row/row/RowContainer.jsx
@@ -1,8 +1,7 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import { shouldRowUpdate } from '../../../../util/shouldComponentUpdate';
-
-const { object } = React.PropTypes;
 
 export default DecoratedComponent => (
     class RowContainer extends Component {

--- a/src/components/layout/table-row/row/cell/DragHandle.js
+++ b/src/components/layout/table-row/row/cell/DragHandle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { prefix } from './../../../../../util/prefix';
 import { gridConfig } from './../../../../../constants/GridConstants';

--- a/src/components/layout/table-row/row/cell/Editor.jsx
+++ b/src/components/layout/table-row/row/cell/Editor.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Input } from './Input';
 import { gridConfig } from './../../../../../constants/GridConstants';
 import { prefix } from './../../../../../util/prefix';

--- a/src/components/layout/table-row/row/cell/Input.jsx
+++ b/src/components/layout/table-row/row/cell/Input.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import {
     updateCellValue

--- a/src/components/layout/table-row/row/cell/TreeArrow.jsx
+++ b/src/components/layout/table-row/row/cell/TreeArrow.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { prefix } from './../../../../../util/prefix';
 import { gridConfig } from './../../../../../constants/GridConstants';

--- a/src/components/plugins/bulkactions/Toolbar.jsx
+++ b/src/components/plugins/bulkactions/Toolbar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { prefix } from '../../../util/prefix';
 import { stateGetter } from '../../../util/stateGetter';

--- a/src/components/plugins/editor/Inline.jsx
+++ b/src/components/plugins/editor/Inline.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 

--- a/src/components/plugins/editor/inline/Button.jsx
+++ b/src/components/plugins/editor/inline/Button.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { prefix } from './../../../../util/prefix';
 import { fireEvent } from './../../../../util/fire';

--- a/src/components/plugins/errorhandler/Message.jsx
+++ b/src/components/plugins/errorhandler/Message.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { prefix } from '../../../util/prefix';
 import { stateGetter } from '../../../util/stateGetter';

--- a/src/components/plugins/gridactions/ActionColumn.jsx
+++ b/src/components/plugins/gridactions/ActionColumn.jsx
@@ -1,6 +1,7 @@
+import PropTypes from 'prop-types';
 /* eslint-disable react/no-did-update-set-state */
 /* eslint-disable react/no-set-state */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { Menu } from './actioncolumn/Menu';
 import {

--- a/src/components/plugins/gridactions/actioncolumn/Menu.jsx
+++ b/src/components/plugins/gridactions/actioncolumn/Menu.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { ConnectedMenu as MenuCmp } from './../../../core/menu/Menu';
 import { handleEditClick } from './../../../../util/handleEditClick';
 

--- a/src/components/plugins/loader/LoadingBar.jsx
+++ b/src/components/plugins/loader/LoadingBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { prefix } from '../../../util/prefix';
 import { isPluginEnabled } from '../../../util/isPluginEnabled';
 import { gridConfig } from '../../../constants/GridConstants';

--- a/src/components/plugins/pager/Pager.jsx
+++ b/src/components/plugins/pager/Pager.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 import { Button } from './toolbar/Button';

--- a/src/components/plugins/pager/toolbar/Button.jsx
+++ b/src/components/plugins/pager/toolbar/Button.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { prefix } from './../../../../util/prefix';
 import { gridConfig } from './../../../../constants/GridConstants';
 

--- a/src/components/plugins/pager/toolbar/Description.jsx
+++ b/src/components/plugins/pager/toolbar/Description.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export const Description = ({
     toolbarRenderer, pageIndex, pageSize, total, currentRecords, recordType

--- a/src/components/plugins/selection/CheckBox.jsx
+++ b/src/components/plugins/selection/CheckBox.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { prefix } from '../../../util/prefix';
 import { fireEvent } from '../../../util/fire';

--- a/src/constants/GridConstants.js
+++ b/src/constants/GridConstants.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 export const ROW_HEIGHT = 5000;
 


### PR DESCRIPTION
Fixes "Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead."