### PR TITLE
bug #154 - updated editableFuncArgs to just take editorData

### DIFF
--- a/src/components/layout/table-row/row/cell/Editor.jsx
+++ b/src/components/layout/table-row/row/cell/Editor.jsx
@@ -52,9 +52,9 @@ export const Editor = ({
         : rawValue;
 
     const editableFuncArgs = {
-        row: editorData && editorData.get(rowId)
-            ? editorData.get(rowId).toJS()
-            : {},
+        row: editorData && editorData.toJS
+            ? editorData.toJS()
+            : editorData || {},
         isRowSelected,
         store
     };

--- a/test/components/layout/table-row/row/cell/Editor.test.js
+++ b/test/components/layout/table-row/row/cell/Editor.test.js
@@ -44,6 +44,21 @@ describe('The Editor Component', () => {
             .toEqual('<span class="react-grid-inactive">Michael Jordan</span>');
     });
 
+    it('Should return an editable field', () => {
+        const customProps = {
+            ...props,
+            isEditable: true,
+            isRowSelected: true
+        };
+
+        const cmp = mount(<Editor { ...customProps } />);
+
+        expect(cmp.html())
+            .toEqual(
+                '<span class="react-grid-editor-wrapper"><input type="text" value="Michael Jordan"></span>' // eslint-disable-line max-len
+            );
+    });
+
     it('Should clean props from an object', () => {
 
         expect(cleanProps({
@@ -83,6 +98,49 @@ describe('The Editor Component', () => {
             .toEqual(
                 'checkbox',
                 'Custom render should have created a checkbox'
+            );
+    });
+
+    it('Should conditionally return an editable field', () => {
+        const customProps = {
+            ...props,
+            columns: [
+                {
+                    dataIndex: 'name',
+                    editable: ({ row }) => {
+                        if (row && row.values) {
+                            return row.values.name === 'Michael Jordan';
+                        }
+                        return false;
+                    }
+                },
+                {
+                    dataIndex: 'position'
+                }
+            ],
+            editorState: new testState({
+                ['row-0']: new EditorRecord({
+                    key: 'row-0',
+                    values: Map({
+                        name: 'Michael Jordan'
+                    }),
+                    rowIndex: 0,
+                    top: null,
+                    valid: null,
+                    isCreate: false,
+                    overrides: {},
+                    previousValues: {},
+                    lastUpdate: 0
+                })
+            }),
+            isEditable: true
+        };
+
+        const cmp = mount(<Editor { ...customProps } />);
+
+        expect(cmp.html())
+            .toEqual(
+                '<span class="react-grid-editor-wrapper"><input type="text" value="Michael Jordan"></span>' // eslint-disable-line max-len
             );
     });
 


### PR DESCRIPTION
Purpose: This resolves an issue with editableFunctionArgs returning undefined for the row. 

The fix for 154, cfe896d47a10041dd353981d8a9c7dd966208bc3, swapped the editableFuncArgs' row to editorData instead of editorState but is still attempting to get the rowId for the editorData which returns undefined because the editorData is already the row we're acting on. 

For example, the following column would always return false because of row being undefined:

        editable: ({ row }) => {
            if (row && row.values) {
                return row.values.name === 'Michael Jordan';
            }
            return false;
        },