### PR TITLE
Update to stateGetter for non-immutable store

### DIFF
--- a/src/util/stateGetter.js
+++ b/src/util/stateGetter.js
@@ -51,5 +51,6 @@ export const get = (state, key, entry) => {
         return null;
     }
 
-    return stateItem.get(entry);
+    const isStateImmutable = typeof stateItem.get === 'function';
+    return isStateImmutable ? stateItem.get(entry) : stateItem[entry];
 };

--- a/test/util/stateGetter.test.js
+++ b/test/util/stateGetter.test.js
@@ -149,4 +149,12 @@ describe('State Getter Function', () => {
         ).toEqual(List([1]));
     });
 
+    it('Should return state when its not stored using immutable', () => {
+        const state = { data: { thing: [1] } };
+        const props = {};
+
+        expect(
+            stateGetter(state, props, 'data', 'thing')
+        ).toEqual([1]);
+    });
 });


### PR DESCRIPTION
Changes made to util/stateGetter and test/util/stateGetter.test

Checks to make sure stateItem is an immutable before doing the .get