### PR TITLE
Add guard for global.navigation in Column.jsx

### DIFF
--- a/src/components/layout/header/Column.jsx
+++ b/src/components/layout/header/Column.jsx
@@ -17,7 +17,7 @@ import {
 import { reorderColumn } from './../../../actions/core/ColumnManager';
 import { setSortDirection } from './../../../actions/GridActions';
 
-const isChrome = /Chrome/.test(navigator.userAgent)
+const isChrome = navigator && /Chrome/.test(navigator.userAgent)
     && /Google Inc/.test(navigator.vendor);
 
 export const Column = ({


### PR DESCRIPTION
Because the Column.jsx is making use of global.navigator without any guard, you cannot shallow render any component that imports react-redux-grid.

This means that you have to mock out any imports of react-redux-grid to test the components that wrap them.

Simply adding a check for navigator allows the parent component that imports react-redux-grid to be shallowly rendered and tested.

Another possible solution would be to run the check each time Column.render is called but I didn't go this route to preserve the current performance characteristic of the current isChrome check.