### PR TITLE
For Tree View actions the total param is now passed along

### DIFF
--- a/src/actions/GridActions.js
+++ b/src/actions/GridActions.js
@@ -70,7 +70,8 @@ export const getAsyncData = ({
                             showTreeRootNode,
                             parentId: extraParams.parentId,
                             partial: response.partial,
-                            editMode: extraParams.editMode
+                            editMode: extraParams.editMode,
+                            total: response.total
                         }));
                     }
 
@@ -374,7 +375,7 @@ export const setData = ({ data, stateKey, editMode }) => ({
 });
 
 export const setTreeData = ({
-    data, stateKey, showTreeRootNode, partial, parentId, editMode
+    data, stateKey, showTreeRootNode, partial, parentId, editMode, total
 }) => {
 
     // if this is a partial update to
@@ -386,7 +387,8 @@ export const setTreeData = ({
             stateKey,
             gridType: 'tree',
             showTreeRootNode,
-            parentId
+            parentId,
+            total
         };
     }
 
@@ -403,7 +405,8 @@ export const setTreeData = ({
         stateKey,
         gridType: 'tree',
         treeData: data,
-        editMode
+        editMode,
+        total
     };
 };
 

--- a/src/reducers/actionHelpers/datasource.js
+++ b/src/reducers/actionHelpers/datasource.js
@@ -35,7 +35,7 @@ export const setData = (state, {
 };
 
 export const setPartialTreeData = (state, {
-    data, parentId, showTreeRootNode, stateKey
+    data, parentId, showTreeRootNode, stateKey, total
 }) => {
 
     const tree = state.getIn([stateKey, 'treeData']);
@@ -58,7 +58,7 @@ export const setPartialTreeData = (state, {
         currentRecords: updatedFlat,
         treeData: updatedTree,
         proxy: updatedFlat,
-        total: updatedFlat.count(),
+        total: total || updatedFlat.count(),
         lastUpdate: generateLastUpdate()
     }, DataSource, 'mergeIn');
 };

--- a/test/actions/GridActions.test.js
+++ b/test/actions/GridActions.test.js
@@ -785,7 +785,8 @@ describe('The setTreeData action', () => {
             type: '@@react-redux-grid/SET_DATA',
             stateKey: 'tree-grid',
             gridType: 'tree',
-            treeData: data
+            treeData: data,
+            total: undefined
         });
 
         expect(List.isList(expectedData))
@@ -815,7 +816,8 @@ describe('The setTreeData action', () => {
             stateKey: 'tree-grid',
             editMode: 'inline',
             gridType: 'tree',
-            treeData: data
+            treeData: data,
+            total: undefined
         });
 
         expect(List.isList(expectedData))


### PR DESCRIPTION
Much the same as Grid view, manually setting the results total from the datasource for a Tree view can very useful. Particularly in the case of paging when your paged data needs to reflect only parent/root elements.