### PR TITLE
Fix `findDOMNode was called on an unmounted component.`

### DIFF
--- a/src/components/layout/FixedHeader.jsx
+++ b/src/components/layout/FixedHeader.jsx
@@ -163,7 +163,7 @@ class FixedHeader extends Component {
     }
 
     componentDidMount() {
-
+        this._isMounted = true;
         const { plugins } = this.props;
 
         const isSticky = isPluginEnabled(plugins, 'STICKY_HEADER');
@@ -181,15 +181,20 @@ class FixedHeader extends Component {
     }
 
     componentDidUpdate() {
-
         if (!this.updateFunc) {
-            this.updateFunc = debounce(this.getScrollWidth, 200);
+            const getScrollWidth = () => {
+                if (this._isMounted) {
+                    this.getScrollWidth();
+                }
+            };
+            this.updateFunc = debounce(getScrollWidth, 200);
         }
 
         this.updateFunc();
     }
 
     componentWillUnmount() {
+        this._isMounted = false;
         if (this.scrollTarget) {
             this.scrollTarget.removeEventListener(
                 'scroll', this._scrollListener
@@ -208,6 +213,7 @@ class FixedHeader extends Component {
             headerOffset: 0,
             classes: []
         };
+        this._isMounted = false;
         this.handleDrag = throttle(handleDrag, this, 5);
         this.shouldComponentUpdate = shouldHeaderUpdate.bind(this);
     }

--- a/test/components/layout/FixedHeader.test.js
+++ b/test/components/layout/FixedHeader.test.js
@@ -191,4 +191,29 @@ describe('The Grid Fixed header component', () => {
 
     });
 
+    it('Should not call getScrollWidth when already unmounted', (done) => {
+
+        const component = mountWithContext(<FixedHeader { ...props } />);
+        const instance = component.instance();
+        const getScrollWidth =
+            expect
+                .spyOn(instance, 'getScrollWidth')
+                .andCallThrough();
+
+        instance.componentDidUpdate();
+        component.unmount();
+
+        setTimeout(() => {
+
+            expect(
+                getScrollWidth
+            ).toNotHaveBeenCalled();
+
+            getScrollWidth.restore();
+
+            done();
+
+        }, 500);
+    });
+
 });


### PR DESCRIPTION
Added a flag to track if component is still mounted in order to avoid… calling getScrollWidth (which triggers a findDOMNode) after a component is unmounted. Suggestions comes from a React blog post: https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html